### PR TITLE
fix(offline): replace isNew timestamp heuristic with explicit isLocalOnly flag

### DIFF
--- a/app/src/main/java/com/jotty/android/data/local/ChecklistDao.kt
+++ b/app/src/main/java/com/jotty/android/data/local/ChecklistDao.kt
@@ -1,0 +1,42 @@
+package com.jotty.android.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ChecklistDao {
+
+    @Query("SELECT * FROM checklists WHERE instanceId = :instanceId AND isDeleted = 0 ORDER BY updatedAt DESC")
+    fun getAllChecklistsFlow(instanceId: String): Flow<List<ChecklistEntity>>
+
+    @Query("SELECT * FROM checklists WHERE instanceId = :instanceId AND isDeleted = 0 ORDER BY updatedAt DESC")
+    suspend fun getAllChecklists(instanceId: String): List<ChecklistEntity>
+
+    @Query("SELECT * FROM checklists WHERE id = :id AND isDeleted = 0")
+    suspend fun getById(id: String): ChecklistEntity?
+
+    @Query("SELECT * FROM checklists WHERE instanceId = :instanceId AND (isDirty = 1 OR isDeleted = 1)")
+    suspend fun getDirty(instanceId: String): List<ChecklistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: ChecklistEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(entities: List<ChecklistEntity>)
+
+    @Update
+    suspend fun update(entity: ChecklistEntity)
+
+    @Query("UPDATE checklists SET isDeleted = 1, isDirty = 1 WHERE id = :id")
+    suspend fun markAsDeleted(id: String)
+
+    @Query("DELETE FROM checklists WHERE id = :id")
+    suspend fun delete(id: String)
+
+    @Query("DELETE FROM checklists WHERE instanceId = :instanceId")
+    suspend fun deleteAll(instanceId: String)
+}

--- a/app/src/main/java/com/jotty/android/data/local/ChecklistEntity.kt
+++ b/app/src/main/java/com/jotty/android/data/local/ChecklistEntity.kt
@@ -1,0 +1,165 @@
+package com.jotty.android.data.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.jotty.android.data.api.Checklist
+import com.jotty.android.data.api.ChecklistItem
+
+private val gson = Gson()
+
+/**
+ * Pending item operation recorded while offline. Replayed against the server on next sync.
+ * [path] is the positional API path (e.g. "0", "0.1") at the time the op was created.
+ * Paths may be stale if the server was modified concurrently; failing ops are skipped.
+ */
+data class PendingItemOp(
+    val type: String,          // CHECK, UNCHECK, ADD, DELETE, UPDATE_TEXT
+    val path: String? = null,  // positional path for existing-item ops
+    val text: String? = null,  // ADD / UPDATE_TEXT
+    val parentIndex: String? = null, // ADD with parent (project type)
+)
+
+@Entity(tableName = "checklists", indices = [Index("instanceId")])
+data class ChecklistEntity(
+    @PrimaryKey val id: String,
+    val title: String,
+    val category: String,
+    val type: String,
+    /** Gson-serialized List<ChecklistItem> — the full item tree. */
+    val itemsJson: String = "[]",
+    /** Gson-serialized List<PendingItemOp> — replayed against the server on sync. */
+    val pendingOpsJson: String = "[]",
+    val createdAt: String,
+    val updatedAt: String,
+    val isDirty: Boolean = false,
+    val isDeleted: Boolean = false,
+    val instanceId: String,
+    @ColumnInfo(defaultValue = "0")
+    val isLocalOnly: Boolean = false,
+)
+
+// ─── Type tokens ────────────────────────────────────────────────────────────
+
+private val itemListType = object : TypeToken<List<ChecklistItem>>() {}.type
+private val opListType = object : TypeToken<List<PendingItemOp>>() {}.type
+
+fun ChecklistEntity.items(): List<ChecklistItem> =
+    runCatching { gson.fromJson<List<ChecklistItem>>(itemsJson, itemListType) }
+        .getOrDefault(emptyList())
+
+fun ChecklistEntity.pendingOps(): List<PendingItemOp> =
+    runCatching { gson.fromJson<List<PendingItemOp>>(pendingOpsJson, opListType) }
+        .getOrDefault(emptyList())
+
+// ─── Conversion ─────────────────────────────────────────────────────────────
+
+fun ChecklistEntity.toChecklist(): Checklist = Checklist(
+    id = id,
+    title = title,
+    category = category,
+    type = type,
+    items = items(),
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun Checklist.toEntity(instanceId: String, isDirty: Boolean = false): ChecklistEntity =
+    ChecklistEntity(
+        id = id,
+        title = title,
+        category = category,
+        type = type,
+        itemsJson = gson.toJson(items),
+        pendingOpsJson = "[]",
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        isDirty = isDirty,
+        isDeleted = false,
+        instanceId = instanceId,
+        isLocalOnly = false,
+    )
+
+// ─── Local item tree mutation ────────────────────────────────────────────────
+
+/** Apply a [PendingItemOp] to a list of items, returning the modified list. */
+fun applyOpToItems(items: List<ChecklistItem>, op: PendingItemOp): List<ChecklistItem> =
+    when (op.type) {
+        "CHECK" -> op.path?.let { updateAtPath(items, it) { i -> i.copy(completed = true) } } ?: items
+        "UNCHECK" -> op.path?.let { updateAtPath(items, it) { i -> i.copy(completed = false) } } ?: items
+        "UPDATE_TEXT" -> op.path?.let { updateAtPath(items, it) { i -> i.copy(text = op.text ?: i.text) } } ?: items
+        "DELETE" -> op.path?.let { deleteAtPath(items, it) } ?: items
+        "ADD" -> {
+            if (op.parentIndex == null) {
+                items + ChecklistItem(index = items.size, text = op.text ?: "")
+            } else {
+                // Child index must be relative to the parent's children, not the root list.
+                updateAtPath(items, op.parentIndex) { parent ->
+                    val children = parent.children ?: emptyList()
+                    parent.copy(children = children + ChecklistItem(index = children.size, text = op.text ?: ""))
+                }
+            }
+        }
+        else -> items
+    }
+
+/**
+ * Returns null if any segment of [path] is not a valid integer.
+ * Callers treat null as a no-op (stale or malformed path).
+ */
+private fun pathSegments(path: String): List<Int>? =
+    path.split(".").map { it.toIntOrNull() ?: return null }
+
+private fun updateAtPath(
+    items: List<ChecklistItem>,
+    path: String,
+    transform: (ChecklistItem) -> ChecklistItem,
+): List<ChecklistItem> {
+    val segments = pathSegments(path) ?: return items
+    return updateAtSegments(items, segments, transform)
+}
+
+private fun updateAtSegments(
+    items: List<ChecklistItem>,
+    segments: List<Int>,
+    transform: (ChecklistItem) -> ChecklistItem,
+): List<ChecklistItem> {
+    if (segments.isEmpty()) return items
+    val idx = segments[0]
+    if (idx < 0 || idx >= items.size) return items
+    return if (segments.size == 1) {
+        items.toMutableList().also { it[idx] = transform(it[idx]) }
+    } else {
+        items.toMutableList().also { list ->
+            val parent = list[idx]
+            list[idx] = parent.copy(
+                children = updateAtSegments(parent.children ?: emptyList(), segments.drop(1), transform),
+            )
+        }
+    }
+}
+
+private fun deleteAtPath(items: List<ChecklistItem>, path: String): List<ChecklistItem> {
+    val segments = pathSegments(path) ?: return items
+    return deleteAtSegments(items, segments)
+}
+
+private fun deleteAtSegments(items: List<ChecklistItem>, segments: List<Int>): List<ChecklistItem> {
+    if (segments.isEmpty()) return items
+    val idx = segments[0]
+    if (idx < 0 || idx >= items.size) return items
+    return if (segments.size == 1) {
+        items.toMutableList().also { it.removeAt(idx) }
+            .mapIndexed { i, item -> item.copy(index = i) }
+    } else {
+        items.toMutableList().also { list ->
+            val parent = list[idx]
+            val newChildren = deleteAtSegments(parent.children ?: emptyList(), segments.drop(1))
+                .mapIndexed { i, item -> item.copy(index = i) }
+            list[idx] = parent.copy(children = newChildren)
+        }
+    }
+}

--- a/app/src/main/java/com/jotty/android/data/local/JottyDatabase.kt
+++ b/app/src/main/java/com/jotty/android/data/local/JottyDatabase.kt
@@ -31,6 +31,13 @@ abstract class JottyDatabase : RoomDatabase() {
                 db.execSQL(
                     "ALTER TABLE notes ADD COLUMN isLocalOnly INTEGER NOT NULL DEFAULT 0"
                 )
+                // Best-effort rescue of pre-existing local-only notes: if a dirty,
+                // non-deleted note has createdAt == updatedAt it was almost certainly
+                // created offline and never synced. Mark it so syncNote() calls
+                // createNote instead of updateNote (which would 404 on an unknown ID).
+                db.execSQL(
+                    "UPDATE notes SET isLocalOnly = 1 WHERE isDirty = 1 AND isDeleted = 0 AND createdAt = updatedAt"
+                )
             }
         }
 

--- a/app/src/main/java/com/jotty/android/data/local/JottyDatabase.kt
+++ b/app/src/main/java/com/jotty/android/data/local/JottyDatabase.kt
@@ -8,19 +8,20 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
- * Room database for offline note storage.
- * Database version: 2
+ * Room database for offline storage.
+ * Database version: 3
  *
- * v1 → v2: add isLocalOnly column (default 0 = false) to distinguish notes
- * created offline-only from notes that exist on the server.
+ * v1 → v2: add isLocalOnly column to notes.
+ * v2 → v3: add checklists table for offline checklist support.
  */
 @Database(
-    entities = [NoteEntity::class],
-    version = 2,
+    entities = [NoteEntity::class, ChecklistEntity::class],
+    version = 3,
     exportSchema = false
 )
 abstract class JottyDatabase : RoomDatabase() {
     abstract fun noteDao(): NoteDao
+    abstract fun checklistDao(): ChecklistDao
 
     companion object {
         @Volatile
@@ -41,6 +42,31 @@ abstract class JottyDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS checklists (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        title TEXT NOT NULL,
+                        category TEXT NOT NULL,
+                        type TEXT NOT NULL,
+                        itemsJson TEXT NOT NULL DEFAULT '[]',
+                        pendingOpsJson TEXT NOT NULL DEFAULT '[]',
+                        createdAt TEXT NOT NULL,
+                        updatedAt TEXT NOT NULL,
+                        isDirty INTEGER NOT NULL DEFAULT 0,
+                        isDeleted INTEGER NOT NULL DEFAULT 0,
+                        instanceId TEXT NOT NULL,
+                        isLocalOnly INTEGER NOT NULL DEFAULT 0
+                    )
+                    """.trimIndent()
+                )
+                // Index mirrors @Entity(indices=[Index("instanceId")]) for DAO filter queries.
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_checklists_instanceId ON checklists (instanceId)")
+            }
+        }
+
         fun getDatabase(context: Context): JottyDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -48,7 +74,7 @@ abstract class JottyDatabase : RoomDatabase() {
                     JottyDatabase::class.java,
                     "jotty_database"
                 )
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/jotty/android/data/local/JottyDatabase.kt
+++ b/app/src/main/java/com/jotty/android/data/local/JottyDatabase.kt
@@ -4,14 +4,19 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
  * Room database for offline note storage.
- * Database version: 1
+ * Database version: 2
+ *
+ * v1 → v2: add isLocalOnly column (default 0 = false) to distinguish notes
+ * created offline-only from notes that exist on the server.
  */
 @Database(
     entities = [NoteEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class JottyDatabase : RoomDatabase() {
@@ -21,16 +26,23 @@ abstract class JottyDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: JottyDatabase? = null
 
-        /**
-         * Get or create the database instance.
-         */
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE notes ADD COLUMN isLocalOnly INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): JottyDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     JottyDatabase::class.java,
                     "jotty_database"
-                ).build()
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/jotty/android/data/local/NoteEntity.kt
+++ b/app/src/main/java/com/jotty/android/data/local/NoteEntity.kt
@@ -1,5 +1,6 @@
 package com.jotty.android.data.local
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.jotty.android.data.api.Note
@@ -17,9 +18,14 @@ data class NoteEntity(
     val createdAt: String,
     val updatedAt: String,
     val encrypted: Boolean?,
-    val isDirty: Boolean = false, // True if locally modified and needs sync
-    val isDeleted: Boolean = false, // True if marked for deletion
-    val instanceId: String, // Which Jotty instance this note belongs to
+    val isDirty: Boolean = false,
+    val isDeleted: Boolean = false,
+    val instanceId: String,
+    // True for notes created offline that have never been pushed to the server.
+    // Used instead of the fragile createdAt == updatedAt heuristic to decide
+    // whether syncNote() should call createNote or updateNote.
+    @ColumnInfo(defaultValue = "0")
+    val isLocalOnly: Boolean = false,
 )
 
 /**

--- a/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
@@ -1,0 +1,415 @@
+package com.jotty.android.data.local
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.room.withTransaction
+import com.google.gson.Gson
+import com.jotty.android.data.api.AddItemRequest
+import com.jotty.android.data.api.Checklist
+import com.jotty.android.data.api.CreateChecklistRequest
+import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.api.UpdateChecklistRequest
+import com.jotty.android.data.api.UpdateItemRequest
+import com.jotty.android.util.AppLog
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.util.UUID
+
+private val gson = Gson()
+
+/**
+ * Manages offline checklist storage and synchronisation with the Jotty API.
+ *
+ * Item mutations while offline are:
+ *  1. Applied immediately to the local [itemsJson] blob so the UI reflects the change.
+ *  2. Recorded as [PendingItemOp] entries replayed on the next successful sync.
+ *
+ * Paths in pending ops are positional (e.g. "0", "0.1") captured at mutation time.
+ * If the server was also modified during the offline period a path may be stale; the
+ * replay silently skips such failing ops — acceptable for a single-user homelab app.
+ */
+class OfflineChecklistsRepository(
+    private val context: Context,
+    private val database: JottyDatabase,
+    private val instanceId: String,
+    private val api: JottyApi,
+    initialOnlineOverride: Boolean? = null,
+    private val registerNetworkCallback: Boolean = true,
+) {
+    private val checklistDao = database.checklistDao()
+
+    private val scopeExceptionHandler = CoroutineExceptionHandler { _, t ->
+        AppLog.d(TAG, "Background coroutine failed: ${t.message}")
+    }
+    private val coroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO + scopeExceptionHandler)
+
+    private val _isOnline = MutableStateFlow(initialOnlineOverride ?: checkConnectivity())
+    val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    private val _isSyncing = MutableStateFlow(false)
+    val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
+
+    private val _conflictsDetected = MutableStateFlow(0)
+    val conflictsDetected: StateFlow<Int> = _conflictsDetected.asStateFlow()
+
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    @Volatile private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    @Volatile private var closed = false
+
+    init {
+        if (registerNetworkCallback) {
+            connectivityManager?.let { cm ->
+                val req = NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+                val cb = object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        if (closed) return
+                        AppLog.d(TAG, "Network available")
+                        _isOnline.value = true
+                        coroutineScope.launch { syncChecklists() }
+                    }
+
+                    override fun onLost(network: Network) {
+                        if (closed) return
+                        AppLog.d(TAG, "Network lost")
+                        _isOnline.value = false
+                    }
+                }
+                networkCallback = cb
+                cm.registerNetworkCallback(req, cb)
+                AppLog.d(TAG, "Network callback registered (instance: $instanceId)")
+            }
+        }
+    }
+
+    fun close() {
+        if (closed) return
+        closed = true
+        networkCallback?.let {
+            connectivityManager?.unregisterNetworkCallback(it)
+            networkCallback = null
+        }
+        coroutineScope.cancel()
+        AppLog.d(TAG, "Closed (instance: $instanceId)")
+    }
+
+    private fun checkConnectivity(): Boolean {
+        val cm = connectivityManager ?: return false
+        val net = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(net) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    // ─── Flows ──────────────────────────────────────────────────────────────
+
+    fun getChecklistsFlow(): Flow<List<Checklist>> =
+        checklistDao.getAllChecklistsFlow(instanceId)
+            .map { it.map { e -> e.toChecklist() } }
+            .flowOn(Dispatchers.IO)
+
+    fun clearConflictNotification() { _conflictsDetected.value = 0 }
+
+    // ─── CRUD ───────────────────────────────────────────────────────────────
+
+    suspend fun createChecklist(
+        title: String,
+        type: String = "simple",
+        category: String = "Uncategorized",
+    ): Result<Checklist> = withContext(Dispatchers.IO) {
+        runCatching {
+            val now = Instant.now().toString()
+            val entity = ChecklistEntity(
+                id = UUID.randomUUID().toString(),
+                title = title,
+                category = category,
+                type = type,
+                itemsJson = "[]",
+                pendingOpsJson = "[]",
+                createdAt = now,
+                updatedAt = now,
+                isDirty = true,
+                isDeleted = false,
+                instanceId = instanceId,
+                isLocalOnly = true,
+            )
+            checklistDao.insert(entity)
+            AppLog.d(TAG, "Checklist created locally: ${entity.id}")
+            // Do not inline-sync here: syncChecklist swaps the local PK for the server ID,
+            // which would invalidate the returned checklist. The network callback triggers
+            // syncChecklists() as soon as the device is online.
+            entity.toChecklist()
+        }
+    }
+
+    suspend fun deleteChecklist(id: String): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val entity = checklistDao.getById(id)
+            if (entity != null && entity.isLocalOnly) {
+                checklistDao.delete(id)
+                AppLog.d(TAG, "Local-only checklist hard-deleted: $id")
+            } else {
+                checklistDao.markAsDeleted(id)
+                AppLog.d(TAG, "Checklist marked for deletion: $id")
+                if (_isOnline.value) syncDeletedChecklist(id)
+            }
+        }
+    }
+
+    // ─── Item operations ────────────────────────────────────────────────────
+
+    suspend fun addItem(
+        checklistId: String,
+        text: String,
+        parentIndex: String? = null,
+    ): Result<Checklist> = withContext(Dispatchers.IO) {
+        runCatching {
+            if (_isOnline.value) {
+                val response = api.addChecklistItem(
+                    checklistId,
+                    AddItemRequest(text = text, parentIndex = parentIndex),
+                )
+                // Refresh local cache from server
+                val fresh = api.getChecklists().checklists.find { it.id == checklistId }
+                if (fresh != null) checklistDao.insert(fresh.toEntity(instanceId))
+                response.let {
+                    checklistDao.getById(checklistId)?.toChecklist()
+                        ?: throw Exception("Checklist not found")
+                }
+            } else {
+                val op = PendingItemOp(type = "ADD", text = text, parentIndex = parentIndex)
+                applyOpLocally(checklistId, op)
+            }
+        }
+    }
+
+    suspend fun checkItem(checklistId: String, path: String): Result<Checklist> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                if (_isOnline.value) {
+                    api.checkItem(checklistId, path)
+                    refreshFromServer(checklistId)
+                } else {
+                    applyOpLocally(checklistId, PendingItemOp(type = "CHECK", path = path))
+                }
+            }
+        }
+
+    suspend fun uncheckItem(checklistId: String, path: String): Result<Checklist> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                if (_isOnline.value) {
+                    api.uncheckItem(checklistId, path)
+                    refreshFromServer(checklistId)
+                } else {
+                    applyOpLocally(checklistId, PendingItemOp(type = "UNCHECK", path = path))
+                }
+            }
+        }
+
+    suspend fun deleteItem(checklistId: String, path: String): Result<Checklist> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                if (_isOnline.value) {
+                    api.deleteItem(checklistId, path)
+                    refreshFromServer(checklistId)
+                } else {
+                    applyOpLocally(checklistId, PendingItemOp(type = "DELETE", path = path))
+                }
+            }
+        }
+
+    suspend fun updateItem(
+        checklistId: String,
+        path: String,
+        text: String,
+    ): Result<Checklist> = withContext(Dispatchers.IO) {
+        runCatching {
+            if (_isOnline.value) {
+                api.updateItem(checklistId, path, UpdateItemRequest(text = text))
+                refreshFromServer(checklistId)
+            } else {
+                applyOpLocally(
+                    checklistId,
+                    PendingItemOp(type = "UPDATE_TEXT", path = path, text = text),
+                )
+            }
+        }
+    }
+
+    // ─── Sync ────────────────────────────────────────────────────────────────
+
+    suspend fun syncChecklists(): Result<Unit> = withContext(Dispatchers.IO) {
+        if (_isSyncing.value) return@withContext Result.success(Unit)
+        if (!_isOnline.value) return@withContext Result.failure(Exception("Offline"))
+
+        _isSyncing.value = true
+        AppLog.d(TAG, "Starting sync…")
+        try {
+            val localBefore = checklistDao.getAllChecklists(instanceId).associateBy { it.id }
+
+            val dirty = checklistDao.getDirty(instanceId)
+            AppLog.d(TAG, "${dirty.size} dirty checklists")
+            for (entity in dirty) {
+                if (entity.isDeleted) syncDeletedChecklist(entity.id)
+                else syncChecklist(entity)
+            }
+
+            val serverResponse = api.getChecklists()
+            val serverChecklists = serverResponse.checklists
+            val conflictCopies = mutableListOf<ChecklistEntity>()
+
+            for (serverList in serverChecklists) {
+                val local = localBefore[serverList.id]
+                if (local != null && local.isDirty && !local.isDeleted) {
+                    if (hasConflict(local, serverList)) {
+                        conflictCopies.add(
+                            local.copy(
+                                id = UUID.randomUUID().toString(),
+                                title = "${local.title}$LOCAL_COPY_SUFFIX",
+                                isDirty = false,
+                                isDeleted = false,
+                                pendingOpsJson = "[]",
+                            ),
+                        )
+                        AppLog.d(TAG, "Conflict detected for '${local.title}', local copy created")
+                    }
+                }
+            }
+
+            // Atomic replace: observers see either the old list or the new list, never empty.
+            database.withTransaction {
+                checklistDao.deleteAll(instanceId)
+                checklistDao.insertAll(serverChecklists.map { it.toEntity(instanceId) })
+                if (conflictCopies.isNotEmpty()) checklistDao.insertAll(conflictCopies)
+            }
+            _conflictsDetected.value = if (conflictCopies.isNotEmpty()) conflictCopies.size else 0
+
+            AppLog.d(TAG, "Sync complete — ${serverChecklists.size} checklists from server")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            AppLog.d(TAG, "Sync failed: ${e.message}")
+            Result.failure(e)
+        } finally {
+            _isSyncing.value = false
+        }
+    }
+
+    // ─── Private helpers ─────────────────────────────────────────────────────
+
+    private fun hasConflict(local: ChecklistEntity, server: Checklist): Boolean =
+        local.title != server.title || local.category != server.category
+
+    private suspend fun syncChecklist(entity: ChecklistEntity) {
+        try {
+            if (entity.isLocalOnly) {
+                val response = api.createChecklist(
+                    CreateChecklistRequest(
+                        title = entity.title,
+                        category = entity.category,
+                        type = entity.type,
+                    ),
+                )
+                if (response.data != null) {
+                    // Add any locally-created items
+                    for (item in entity.items()) {
+                        runCatching { api.addChecklistItem(response.data.id, AddItemRequest(text = item.text)) }
+                    }
+                    // Replace local temp ID with server ID
+                    checklistDao.delete(entity.id)
+                    val fresh = api.getChecklists().checklists.find { it.id == response.data.id }
+                    if (fresh != null) checklistDao.insert(fresh.toEntity(instanceId))
+                    AppLog.d(TAG, "Local-only checklist pushed: ${response.data.id}")
+                }
+            } else {
+                // Update metadata
+                api.updateChecklist(
+                    entity.id,
+                    UpdateChecklistRequest(title = entity.title, category = entity.category),
+                )
+                // Replay pending item ops
+                replayPendingOps(entity)
+                // Pull fresh state
+                val fresh = api.getChecklists().checklists.find { it.id == entity.id }
+                if (fresh != null) checklistDao.insert(fresh.toEntity(instanceId))
+                AppLog.d(TAG, "Checklist synced: ${entity.id}")
+            }
+        } catch (e: Exception) {
+            AppLog.d(TAG, "Failed to sync checklist ${entity.id}: ${e.message}")
+        }
+    }
+
+    private suspend fun replayPendingOps(entity: ChecklistEntity) {
+        for (op in entity.pendingOps()) {
+            runCatching {
+                when (op.type) {
+                    "CHECK" -> api.checkItem(entity.id, op.path!!)
+                    "UNCHECK" -> api.uncheckItem(entity.id, op.path!!)
+                    "ADD" -> api.addChecklistItem(
+                        entity.id,
+                        AddItemRequest(text = op.text ?: "", parentIndex = op.parentIndex),
+                    )
+                    "DELETE" -> api.deleteItem(entity.id, op.path!!)
+                    "UPDATE_TEXT" -> api.updateItem(
+                        entity.id, op.path!!, UpdateItemRequest(text = op.text ?: ""),
+                    )
+                }
+            }.onFailure { AppLog.d(TAG, "Pending op ${op.type} failed (stale path?): ${it.message}") }
+        }
+    }
+
+    private suspend fun syncDeletedChecklist(id: String) {
+        try {
+            api.deleteChecklist(id)
+            checklistDao.delete(id)
+            AppLog.d(TAG, "Checklist deleted on server: $id")
+        } catch (e: Exception) {
+            AppLog.d(TAG, "Failed to delete checklist on server $id: ${e.message}")
+        }
+    }
+
+    private suspend fun applyOpLocally(checklistId: String, op: PendingItemOp): Checklist {
+        val entity = checklistDao.getById(checklistId)
+            ?: throw Exception("Checklist not found: $checklistId")
+        val newItems = applyOpToItems(entity.items(), op)
+        val newOps = entity.pendingOps() + op
+        val updated = entity.copy(
+            itemsJson = gson.toJson(newItems),
+            pendingOpsJson = gson.toJson(newOps),
+            isDirty = true,
+            updatedAt = Instant.now().toString(),
+        )
+        checklistDao.update(updated)
+        return updated.toChecklist()
+    }
+
+    private suspend fun refreshFromServer(checklistId: String): Checklist {
+        val fresh = api.getChecklists().checklists.find { it.id == checklistId }
+            ?: throw Exception("Checklist not found on server: $checklistId")
+        checklistDao.insert(fresh.toEntity(instanceId))
+        return fresh
+    }
+
+    companion object {
+        private const val TAG = "OfflineChecklistsRepo"
+        const val LOCAL_COPY_SUFFIX = " (Local copy)"
+    }
+}

--- a/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
@@ -203,18 +203,22 @@ class OfflineNotesRepository(
 
     /**
      * Delete a note (works offline).
+     * If the note only exists locally (never synced), it is hard-deleted immediately —
+     * no server call is made since the server has never seen this ID.
      */
     suspend fun deleteNote(noteId: String): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            // Mark as deleted (soft delete for sync)
-            noteDao.markAsDeleted(noteId)
-            AppLog.d("OfflineNotesRepository", "Note marked for deletion: $noteId")
-
-            // Try to sync if online
-            if (_isOnline.value) {
-                syncDeletedNote(noteId)
+            val note = noteDao.getNoteById(noteId)
+            if (note != null && note.isLocalOnly) {
+                noteDao.deleteNote(noteId)
+                AppLog.d("OfflineNotesRepository", "Local-only note hard-deleted: $noteId")
+            } else {
+                noteDao.markAsDeleted(noteId)
+                AppLog.d("OfflineNotesRepository", "Note marked for deletion: $noteId")
+                if (_isOnline.value) {
+                    syncDeletedNote(noteId)
+                }
             }
-
             Result.success(Unit)
         } catch (e: Exception) {
             AppLog.d("OfflineNotesRepository", "Failed to delete note: ${e.message}")

--- a/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
@@ -146,9 +146,10 @@ class OfflineNotesRepository(
                 createdAt = now,
                 updatedAt = now,
                 encrypted = null,
-                isDirty = true, // Mark as dirty for sync
+                isDirty = true,
                 isDeleted = false,
-                instanceId = instanceId
+                instanceId = instanceId,
+                isLocalOnly = true,
             )
 
             // Save locally
@@ -319,45 +320,39 @@ class OfflineNotesRepository(
 
     /**
      * Sync a single note to the server.
+     * Uses [NoteEntity.isLocalOnly] to decide between create and update — a note is local-only
+     * when it was created offline and has never been pushed to the server, regardless of timestamps.
      */
     private suspend fun syncNote(note: NoteEntity) {
         try {
-            // Check if this is a new note (starts with random UUID) or an existing one
-            val isNew = note.createdAt == note.updatedAt && note.isDirty
-
-            if (isNew) {
-                // Create new note on server
+            if (note.isLocalOnly) {
                 val request = CreateNoteRequest(
                     title = note.title,
                     content = note.content,
                     category = note.category
                 )
                 val response = api.createNote(request)
-                
                 if (response.data != null) {
-                    // Replace local temp ID with server ID
+                    // Swap the local temporary ID for the server-assigned ID.
                     noteDao.deleteNote(note.id)
                     noteDao.insertNote(response.data.toEntity(instanceId, isDirty = false))
                     AppLog.d("OfflineNotesRepository", "Note created on server: ${response.data.id}")
                 }
             } else {
-                // Update existing note on server
                 val request = UpdateNoteRequest(
                     title = note.title,
                     content = note.content,
                     category = note.category
                 )
                 val response = api.updateNote(note.id, request)
-                
                 if (response.data != null) {
-                    // Update local note with server response
                     noteDao.insertNote(response.data.toEntity(instanceId, isDirty = false))
                     AppLog.d("OfflineNotesRepository", "Note updated on server: ${note.id}")
                 }
             }
         } catch (e: Exception) {
             AppLog.d("OfflineNotesRepository", "Failed to sync note ${note.id}: ${e.message}")
-            // Keep note marked as dirty for next sync attempt
+            // Keep note marked as dirty for next sync attempt.
         }
     }
 

--- a/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -60,26 +61,53 @@ class OfflineNotesRepository(
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
 
+    // @Volatile: read from the main thread (close) and the callback thread concurrently.
+    // Null when registerNetworkCallback=false (tests).
+    @Volatile private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    @Volatile private var closed = false
+
     init {
         if (registerNetworkCallback) {
             connectivityManager?.let { cm ->
                 val networkRequest = NetworkRequest.Builder()
                     .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                     .build()
-                cm.registerNetworkCallback(networkRequest, object : ConnectivityManager.NetworkCallback() {
+                val callback = object : ConnectivityManager.NetworkCallback() {
                     override fun onAvailable(network: Network) {
+                        if (closed) return
                         AppLog.d("OfflineNotesRepository", "Network available")
                         _isOnline.value = true
                         coroutineScope.launch { syncNotes() }
                     }
 
                     override fun onLost(network: Network) {
+                        if (closed) return
                         AppLog.d("OfflineNotesRepository", "Network lost")
                         _isOnline.value = false
                     }
-                })
+                }
+                networkCallback = callback
+                cm.registerNetworkCallback(networkRequest, callback)
+                AppLog.d("OfflineNotesRepository", "Network callback registered (instance: $instanceId)")
             }
         }
+    }
+
+    /**
+     * Releases resources held by this repository: unregisters the network callback and
+     * cancels the background coroutine scope. Must be called by the owner when it is
+     * destroyed (e.g. [OfflineNotesViewModel.onCleared]) to prevent leaks.
+     * Safe to call multiple times.
+     */
+    fun close() {
+        if (closed) return
+        closed = true
+        networkCallback?.let {
+            connectivityManager?.unregisterNetworkCallback(it)
+            networkCallback = null
+        }
+        coroutineScope.cancel()
+        AppLog.d("OfflineNotesRepository", "Closed (instance: $instanceId)")
     }
 
     /**

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsScreen.kt
@@ -1,0 +1,47 @@
+package com.jotty.android.ui.checklists
+
+import android.app.Application
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.preferences.SettingsRepository
+
+/**
+ * Wrapper that selects between [OfflineEnabledChecklistsScreen] (offline mode on) and
+ * the plain [ChecklistsScreen] (offline mode off), mirroring the notes pattern.
+ */
+@Composable
+fun OfflineChecklistsScreen(
+    api: JottyApi,
+    settingsRepository: SettingsRepository,
+    instanceId: String,
+    swipeToDeleteEnabled: Boolean = false,
+) {
+    val application = LocalContext.current.applicationContext as Application
+    val vm: OfflineChecklistsViewModel = viewModel(
+        key = instanceId,
+        factory = OfflineChecklistsViewModel.Factory(application, instanceId, api),
+    )
+    val offlineRepository = vm.repository
+    val offlineModeEnabled by settingsRepository.offlineModeEnabled.collectAsState(initial = true)
+
+    LaunchedEffect(offlineModeEnabled, instanceId) {
+        if (offlineModeEnabled) offlineRepository.syncChecklists()
+    }
+
+    if (offlineModeEnabled) {
+        OfflineEnabledChecklistsScreen(
+            offlineRepository = offlineRepository,
+            api = api,
+            settingsRepository = settingsRepository,
+            swipeToDeleteEnabled = swipeToDeleteEnabled,
+        )
+    } else {
+        ChecklistsScreen(
+            api = api,
+            settingsRepository = settingsRepository,
+            swipeToDeleteEnabled = swipeToDeleteEnabled,
+        )
+    }
+}

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsViewModel.kt
@@ -1,0 +1,42 @@
+package com.jotty.android.ui.checklists
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.JottyDatabase
+import com.jotty.android.data.local.OfflineChecklistsRepository
+
+/**
+ * Owns [OfflineChecklistsRepository] for the duration of the Checklists destination.
+ * Calls [OfflineChecklistsRepository.close] in [onCleared] to unregister the network
+ * callback and cancel the coroutine scope — same lifecycle pattern as [OfflineNotesViewModel].
+ */
+class OfflineChecklistsViewModel(
+    application: Application,
+    instanceId: String,
+    api: JottyApi,
+) : AndroidViewModel(application) {
+
+    val repository: OfflineChecklistsRepository = OfflineChecklistsRepository(
+        context = application,
+        database = JottyDatabase.getDatabase(application),
+        instanceId = instanceId,
+        api = api,
+    )
+
+    override fun onCleared() {
+        repository.close()
+    }
+
+    class Factory(
+        private val application: Application,
+        private val instanceId: String,
+        private val api: JottyApi,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T =
+            OfflineChecklistsViewModel(application, instanceId, api) as T
+    }
+}

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
@@ -1,0 +1,703 @@
+package com.jotty.android.ui.checklists
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.jotty.android.R
+import com.jotty.android.data.api.Checklist
+import com.jotty.android.data.api.ChecklistItem
+import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.OfflineChecklistsRepository
+import com.jotty.android.data.preferences.SettingsRepository
+import com.jotty.android.ui.common.ListScreenContent
+import com.jotty.android.ui.common.MainNestedScaffoldContentWindowInsets
+import com.jotty.android.ui.common.mainScreenTabContentPadding
+import com.jotty.android.util.ApiErrorHelper
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun OfflineEnabledChecklistsScreen(
+    offlineRepository: OfflineChecklistsRepository,
+    api: JottyApi,
+    settingsRepository: SettingsRepository,
+    swipeToDeleteEnabled: Boolean = false,
+) {
+    val contentPaddingMode by settingsRepository.contentPaddingMode.collectAsState(initial = "comfortable")
+    val contentVerticalDp = if (contentPaddingMode == "compact") 8 else 16
+
+    val vm: OfflineEnabledChecklistsViewModel = viewModel {
+        OfflineEnabledChecklistsViewModel(offlineRepository, api)
+    }
+
+    val checklists by offlineRepository.getChecklistsFlow().collectAsState(initial = emptyList())
+    val isOnline by offlineRepository.isOnline.collectAsState()
+    val isSyncing by offlineRepository.isSyncing.collectAsState()
+    val conflictsDetected by offlineRepository.conflictsDetected.collectAsState()
+
+    val selectedList by vm.selectedList.collectAsState()
+    val showCreateDialog by vm.showCreateDialog.collectAsState()
+    val searchQuery by vm.searchQuery.collectAsState()
+    val selectedCategory by vm.selectedCategory.collectAsState()
+    val checklistCategories by vm.checklistCategories.collectAsState()
+    val filteredChecklists by vm.filteredChecklists.collectAsState()
+
+    var loading by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val saveFailedMsg = stringResource(R.string.save_failed)
+    val deleteFailedMsg = stringResource(R.string.delete_failed)
+    val savedLocallyMsg = stringResource(R.string.saved_locally)
+
+    fun requestSync(showLoading: Boolean = true) {
+        scope.launch {
+            if (!isOnline) return@launch
+            if (showLoading) loading = true
+            error = null
+            val result = offlineRepository.syncChecklists()
+            if (result.isFailure) {
+                error = ApiErrorHelper.userMessage(
+                    context,
+                    result.exceptionOrNull() ?: Exception("Sync failed"),
+                )
+            }
+            if (showLoading) loading = false
+        }
+    }
+
+    LaunchedEffect(conflictsDetected) {
+        if (conflictsDetected > 0) {
+            val msg = context.getString(R.string.sync_conflicts_detected, conflictsDetected)
+            scope.launch {
+                val result = snackbarHostState.showSnackbar(
+                    message = msg,
+                    actionLabel = context.getString(R.string.view_conflicts),
+                    duration = SnackbarDuration.Long,
+                )
+                if (result == SnackbarResult.ActionPerformed) vm.applyConflictSearchFilter()
+                offlineRepository.clearConflictNotification()
+            }
+        }
+    }
+
+    LaunchedEffect(isOnline, checklists) {
+        vm.loadCategories(isOnline, checklists)
+    }
+
+    BackHandler(enabled = selectedList != null) { vm.setSelectedList(null) }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        contentWindowInsets = MainNestedScaffoldContentWindowInsets,
+    ) { innerPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .mainScreenTabContentPadding(
+                    topComfortDp = contentVerticalDp,
+                    scaffoldInnerPadding = innerPadding,
+                ),
+        ) {
+            val currentList = selectedList
+            if (currentList != null) {
+                OfflineChecklistDetailContent(
+                    checklist = currentList,
+                    offlineRepository = offlineRepository,
+                    isOnline = isOnline,
+                    onBack = { vm.setSelectedList(null) },
+                    onUpdate = { vm.setSelectedList(it) },
+                    onDelete = {
+                        scope.launch {
+                            val result = offlineRepository.deleteChecklist(currentList.id)
+                            if (result.isFailure) {
+                                snackbarHostState.showSnackbar(deleteFailedMsg)
+                            } else if (!isOnline) {
+                                snackbarHostState.showSnackbar(savedLocallyMsg)
+                            }
+                            vm.setSelectedList(null)
+                        }
+                    },
+                    onSaveFailed = { scope.launch { snackbarHostState.showSnackbar(saveFailedMsg) } },
+                    onSavedLocally = { scope.launch { snackbarHostState.showSnackbar(savedLocallyMsg) } },
+                )
+            } else {
+                // Header row: status + actions
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        val statusText = when {
+                            isSyncing -> stringResource(R.string.syncing)
+                            isOnline -> stringResource(R.string.online)
+                            else -> stringResource(R.string.offline)
+                        }
+                        when {
+                            isSyncing -> Icon(
+                                Icons.Default.CloudQueue, contentDescription = statusText,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                            isOnline -> Icon(
+                                Icons.Default.CloudDone, contentDescription = statusText,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                            else -> Icon(
+                                Icons.Default.CloudOff, contentDescription = statusText,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                        Text(
+                            statusText,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Row {
+                        IconButton(
+                            onClick = { requestSync(showLoading = false) },
+                            enabled = isOnline && !isSyncing,
+                        ) {
+                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.cd_refresh))
+                        }
+                        IconButton(onClick = { vm.setShowCreateDialog(true) }) {
+                            Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cd_add))
+                        }
+                    }
+                }
+
+                // Search bar
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { vm.setSearchQuery(it) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    placeholder = { Text(stringResource(R.string.search_notes)) },
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    singleLine = true,
+                )
+
+                // Category chips
+                if (checklistCategories.isNotEmpty()) {
+                    LazyRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentPadding = PaddingValues(vertical = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        item {
+                            FilterChip(
+                                selected = selectedCategory == null,
+                                onClick = { vm.setSelectedCategory(null) },
+                                label = {
+                                    Text(
+                                        stringResource(R.string.all_categories),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                },
+                            )
+                        }
+                        items(checklistCategories, key = { it }) { cat ->
+                            FilterChip(
+                                selected = selectedCategory == cat,
+                                onClick = { vm.toggleCategoryChip(cat) },
+                                label = {
+                                    Text(cat, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                ListScreenContent(
+                    loading = loading,
+                    error = error,
+                    isEmpty = filteredChecklists.isEmpty(),
+                    onRetry = { requestSync() },
+                    emptyIcon = Icons.Default.Checklist,
+                    emptyTitle = stringResource(R.string.no_checklists_yet),
+                    emptySubtitle = stringResource(R.string.tap_add_checklist),
+                    onRefresh = { requestSync() },
+                    content = {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(filteredChecklists, key = { it.id }) { list ->
+                                OfflineChecklistCard(
+                                    checklist = list,
+                                    onClick = { vm.setSelectedList(list) },
+                                    onDelete = {
+                                        scope.launch {
+                                            val result = offlineRepository.deleteChecklist(list.id)
+                                            if (result.isFailure) {
+                                                snackbarHostState.showSnackbar(deleteFailedMsg)
+                                            } else if (!isOnline) {
+                                                snackbarHostState.showSnackbar(savedLocallyMsg)
+                                            }
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        var title by remember { mutableStateOf("") }
+        var isProjectType by remember { mutableStateOf(false) }
+        val untitled = stringResource(R.string.untitled)
+        AlertDialog(
+            onDismissRequest = { vm.setShowCreateDialog(false) },
+            title = { Text(stringResource(R.string.new_checklist)) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    OutlinedTextField(
+                        value = title,
+                        onValueChange = { title = it },
+                        label = { Text(stringResource(R.string.title)) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Checkbox(
+                            checked = isProjectType,
+                            onCheckedChange = { isProjectType = it },
+                        )
+                        Text(
+                            stringResource(R.string.task_project_sub_tasks),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            val result = offlineRepository.createChecklist(
+                                title = title.ifBlank { untitled },
+                                type = if (isProjectType) "task" else "simple",
+                            )
+                            if (result.isSuccess) {
+                                vm.setSelectedList(result.getOrNull())
+                                vm.setShowCreateDialog(false)
+                                if (!isOnline) snackbarHostState.showSnackbar(savedLocallyMsg)
+                            } else {
+                                snackbarHostState.showSnackbar(saveFailedMsg)
+                            }
+                        }
+                    },
+                ) { Text(stringResource(R.string.create)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { vm.setShowCreateDialog(false) }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+// ─── Checklist card ──────────────────────────────────────────────────────────
+
+@Composable
+private fun OfflineChecklistCard(
+    checklist: Checklist,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    val completed = checklist.items.count { it.completed }
+    val total = checklist.items.size
+    val progress = if (total > 0) completed.toFloat() / total else 0f
+    val isProject = checklist.type.equals("project", ignoreCase = true) ||
+        checklist.type.equals("task", ignoreCase = true)
+
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = checklist.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier
+                            .weight(1f, fill = false)
+                            .pointerInput(Unit) {
+                                detectTapGestures(onLongPress = { menuExpanded = true })
+                            },
+                    )
+                    if (isProject) {
+                        Text(
+                            stringResource(R.string.project_label),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
+                if (checklist.items.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LinearProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier.fillMaxWidth().height(4.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.progress_fraction, completed, total),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.edit)) },
+                    onClick = { menuExpanded = false; onClick() },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.delete)) },
+                    onClick = { menuExpanded = false; onDelete() },
+                )
+            }
+        }
+    }
+}
+
+// ─── Detail screen ───────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun OfflineChecklistDetailContent(
+    checklist: Checklist,
+    offlineRepository: OfflineChecklistsRepository,
+    isOnline: Boolean,
+    onBack: () -> Unit,
+    onUpdate: (Checklist) -> Unit,
+    onDelete: () -> Unit,
+    onSaveFailed: () -> Unit,
+    onSavedLocally: () -> Unit,
+) {
+    // Drive item list from the repository flow so offline mutations are reflected immediately.
+    val allChecklists by offlineRepository.getChecklistsFlow().collectAsState(initial = emptyList())
+    val liveChecklist = allChecklists.find { it.id == checklist.id } ?: checklist
+    val items = liveChecklist.items
+
+    var newItemText by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
+
+    val isProject = liveChecklist.type.equals("project", ignoreCase = true) ||
+        liveChecklist.type.equals("task", ignoreCase = true)
+    val flatItems = remember(items, isProject) {
+        if (isProject) flattenItems(items) else items.mapIndexed { i, item -> FlatChecklistItem(item, 0, "$i") }
+    }
+    val toDo = flatItems.filter { !it.item.completed }
+    val done = flatItems.filter { it.item.completed }
+
+    fun handleResult(result: Result<Checklist>) {
+        result.onSuccess { updated ->
+            onUpdate(updated)
+        }.onFailure {
+            if (!isOnline) onSavedLocally() else onSaveFailed()
+        }
+    }
+
+    Column(Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+            }
+            Text(
+                liveChecklist.title,
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = newItemText,
+                onValueChange = { newItemText = it },
+                placeholder = { Text(stringResource(R.string.add_item)) },
+                modifier = Modifier.weight(1f),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        if (newItemText.isNotBlank()) {
+                            val text = newItemText
+                            newItemText = ""
+                            scope.launch {
+                                handleResult(offlineRepository.addItem(liveChecklist.id, text))
+                            }
+                        }
+                    },
+                ),
+            )
+            IconButton(
+                onClick = {
+                    if (newItemText.isNotBlank()) {
+                        val text = newItemText
+                        newItemText = ""
+                        scope.launch {
+                            handleResult(offlineRepository.addItem(liveChecklist.id, text))
+                        }
+                    }
+                },
+            ) {
+                Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add))
+            }
+        }
+
+        if (flatItems.isNotEmpty()) {
+            Text(
+                text = stringResource(R.string.done_progress, done.size, flatItems.size),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            item(key = "header-todo") {
+                SectionLabel(stringResource(R.string.section_to_do, toDo.size))
+            }
+            items(toDo, key = { "todo-${it.apiPath}-${it.item.text}" }) { flat ->
+                OfflineItemRow(
+                    item = flat.item,
+                    depth = flat.depth,
+                    isProject = isProject,
+                    onCheck = {
+                        scope.launch {
+                            handleResult(offlineRepository.checkItem(liveChecklist.id, flat.apiPath))
+                        }
+                    },
+                    onUncheck = {
+                        scope.launch {
+                            handleResult(offlineRepository.uncheckItem(liveChecklist.id, flat.apiPath))
+                        }
+                    },
+                    onDelete = {
+                        scope.launch {
+                            handleResult(offlineRepository.deleteItem(liveChecklist.id, flat.apiPath))
+                        }
+                    },
+                    onUpdate = { text ->
+                        scope.launch {
+                            handleResult(offlineRepository.updateItem(liveChecklist.id, flat.apiPath, text))
+                        }
+                    },
+                    onAddSubItem = if (isProject && flat.depth == 0) {
+                        {
+                            scope.launch {
+                                handleResult(
+                                    offlineRepository.addItem(liveChecklist.id, "", parentIndex = flat.apiPath),
+                                )
+                            }
+                        }
+                    } else null,
+                )
+            }
+            item(key = "header-done") {
+                SectionLabel(stringResource(R.string.section_completed, done.size))
+            }
+            items(done, key = { "done-${it.apiPath}-${it.item.text}" }) { flat ->
+                OfflineItemRow(
+                    item = flat.item,
+                    depth = flat.depth,
+                    isProject = isProject,
+                    onCheck = {
+                        scope.launch {
+                            handleResult(offlineRepository.checkItem(liveChecklist.id, flat.apiPath))
+                        }
+                    },
+                    onUncheck = {
+                        scope.launch {
+                            handleResult(offlineRepository.uncheckItem(liveChecklist.id, flat.apiPath))
+                        }
+                    },
+                    onDelete = {
+                        scope.launch {
+                            handleResult(offlineRepository.deleteItem(liveChecklist.id, flat.apiPath))
+                        }
+                    },
+                    onUpdate = { text ->
+                        scope.launch {
+                            handleResult(offlineRepository.updateItem(liveChecklist.id, flat.apiPath, text))
+                        }
+                    },
+                    onAddSubItem = null,
+                )
+            }
+        }
+    }
+}
+
+// ─── Item row ────────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun OfflineItemRow(
+    item: ChecklistItem,
+    depth: Int = 0,
+    isProject: Boolean = false,
+    onCheck: () -> Unit,
+    onUncheck: () -> Unit,
+    onDelete: () -> Unit,
+    onUpdate: (String) -> Unit,
+    onAddSubItem: (() -> Unit)? = null,
+) {
+    val indent = (depth * 20).dp
+    var isEditing by remember { mutableStateOf(false) }
+    var editText by remember(item.text) { mutableStateOf(item.text) }
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(isEditing) {
+        if (isEditing) focusRequester.requestFocus()
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(modifier = Modifier.width(indent))
+        Checkbox(
+            checked = item.completed,
+            onCheckedChange = { if (it) onCheck() else onUncheck() },
+        )
+        if (isEditing) {
+            OutlinedTextField(
+                value = editText,
+                onValueChange = { editText = it },
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyLarge,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        focusManager.clearFocus()
+                        val trimmed = editText.trim()
+                        if (trimmed.isNotBlank()) onUpdate(trimmed)
+                        isEditing = false
+                    },
+                ),
+            )
+        } else {
+            Text(
+                text = item.text.ifBlank { stringResource(R.string.item_placeholder) },
+                style = MaterialTheme.typography.bodyLarge,
+                textDecoration = if (item.completed) TextDecoration.LineThrough else null,
+                color = if (item.completed) MaterialTheme.colorScheme.onSurfaceVariant
+                else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { isEditing = true; editText = item.text },
+            )
+        }
+        if (isProject && depth == 0 && onAddSubItem != null) {
+            IconButton(onClick = onAddSubItem, modifier = Modifier.size(32.dp)) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = stringResource(R.string.add_sub_task),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+        IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = stringResource(R.string.delete_task),
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SectionLabel(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(vertical = 8.dp, horizontal = 4.dp),
+    )
+}
+
+private data class FlatChecklistItem(val item: ChecklistItem, val depth: Int, val apiPath: String)
+
+private fun flattenItems(
+    items: List<ChecklistItem>,
+    depth: Int = 0,
+    parentPath: String = "",
+): List<FlatChecklistItem> = items.flatMapIndexed { index, item ->
+    val path = if (parentPath.isEmpty()) "$index" else "$parentPath.$index"
+    listOf(FlatChecklistItem(item, depth, path)) +
+        flattenItems(item.children.orEmpty(), depth + 1, path)
+}

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsViewModel.kt
@@ -1,0 +1,78 @@
+package com.jotty.android.ui.checklists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jotty.android.data.api.Checklist
+import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.OfflineChecklistsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class OfflineEnabledChecklistsViewModel(
+    private val offlineRepository: OfflineChecklistsRepository,
+    @Suppress("unused") private val api: JottyApi,
+) : ViewModel() {
+
+    private val _selectedList = MutableStateFlow<Checklist?>(null)
+    val selectedList: StateFlow<Checklist?> = _selectedList.asStateFlow()
+
+    fun setSelectedList(list: Checklist?) { _selectedList.value = list }
+
+    private val _showCreateDialog = MutableStateFlow(false)
+    val showCreateDialog: StateFlow<Boolean> = _showCreateDialog.asStateFlow()
+
+    fun setShowCreateDialog(show: Boolean) { _showCreateDialog.value = show }
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    fun setSearchQuery(q: String) { _searchQuery.value = q }
+
+    private val _checklistCategories = MutableStateFlow<List<String>>(emptyList())
+    val checklistCategories: StateFlow<List<String>> = _checklistCategories.asStateFlow()
+
+    private val _selectedCategory = MutableStateFlow<String?>(null)
+    val selectedCategory: StateFlow<String?> = _selectedCategory.asStateFlow()
+
+    fun setSelectedCategory(category: String?) { _selectedCategory.value = category }
+
+    fun toggleCategoryChip(cat: String) {
+        _selectedCategory.value = if (_selectedCategory.value == cat) null else cat
+    }
+
+    fun applyConflictSearchFilter() { _searchQuery.value = "(Local copy)" }
+
+    fun loadCategories(isOnline: Boolean, localLists: List<Checklist>) {
+        viewModelScope.launch {
+            runCatching {
+                _checklistCategories.value = if (isOnline) {
+                    api.getCategories().categories.checklists.map { it.name }.distinct()
+                } else {
+                    localLists.map { it.category }.distinct()
+                }
+            }.onFailure {
+                _checklistCategories.value = localLists.map { it.category }.distinct()
+            }
+        }
+    }
+
+    val filteredChecklists: StateFlow<List<Checklist>> = combine(
+        offlineRepository.getChecklistsFlow(),
+        _searchQuery,
+        _selectedCategory,
+    ) { lists, query, category ->
+        when {
+            query.isNotBlank() -> lists.filter {
+                it.title.contains(query, ignoreCase = true) ||
+                    it.category.contains(query, ignoreCase = true)
+            }
+            category != null -> lists.filter { it.category == category }
+            else -> lists
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}

--- a/app/src/main/java/com/jotty/android/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/main/MainScreen.kt
@@ -19,7 +19,7 @@ import com.jotty.android.R
 import com.jotty.android.data.api.ApiClient
 import com.jotty.android.data.api.JottyApi
 import com.jotty.android.data.preferences.SettingsRepository
-import com.jotty.android.ui.checklists.ChecklistsScreen
+import com.jotty.android.ui.checklists.OfflineChecklistsScreen
 import com.jotty.android.ui.common.LoadingState
 import com.jotty.android.ui.notes.OfflineNotesScreen
 import com.jotty.android.ui.setup.SetupScreen
@@ -135,11 +135,17 @@ fun MainScreen(
                 modifier = Modifier.fillMaxSize().padding(padding),
             ) {
                 composable(MainRoute.Checklists.route) {
-                    ChecklistsScreen(
-                        api = currentApi,
-                        settingsRepository = settingsRepository,
-                        swipeToDeleteEnabled = swipeToDeleteEnabled,
-                    )
+                    val instanceId = currentInstance?.id
+                    if (instanceId != null) {
+                        OfflineChecklistsScreen(
+                            api = currentApi,
+                            settingsRepository = settingsRepository,
+                            instanceId = instanceId,
+                            swipeToDeleteEnabled = swipeToDeleteEnabled,
+                        )
+                    } else {
+                        LoadingState(Modifier.fillMaxSize(), stringResource(R.string.loading))
+                    }
                 }
                 composable(MainRoute.Notes.route) {
                     val instanceId = currentInstance?.id

--- a/app/src/main/java/com/jotty/android/ui/notes/NotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NotesScreen.kt
@@ -3,6 +3,7 @@ package com.jotty.android.ui.notes
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Note
@@ -145,22 +146,25 @@ fun NotesScreen(
                     singleLine = true,
                 )
                 if (noteCategories.isNotEmpty()) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    LazyRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentPadding = PaddingValues(bottom = 8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        FilterChip(
-                            selected = selectedCategory == null,
-                            onClick = { selectedCategory = null; loadNotes() },
-                            label = {
-                                Text(
-                                    stringResource(R.string.category_all),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            },
-                        )
-                        noteCategories.take(5).forEach { cat ->
+                        item {
+                            FilterChip(
+                                selected = selectedCategory == null,
+                                onClick = { selectedCategory = null; loadNotes() },
+                                label = {
+                                    Text(
+                                        stringResource(R.string.category_all),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                },
+                            )
+                        }
+                        items(noteCategories, key = { it }) { cat ->
                             FilterChip(
                                 selected = selectedCategory == cat,
                                 onClick = { selectedCategory = cat; loadNotes() },

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
@@ -3,6 +3,7 @@ package com.jotty.android.ui.notes
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Note
@@ -238,24 +239,25 @@ fun OfflineEnabledNotesScreen(
 
                     // Category filter chips
                     if (noteCategories.isNotEmpty()) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp),
+                        LazyRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            contentPadding = PaddingValues(vertical = 4.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            FilterChip(
-                                selected = selectedCategory == null,
-                                onClick = { vm.setSelectedCategory(null) },
-                                label = {
-                                    Text(
-                                        stringResource(R.string.all_categories),
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                },
-                            )
-                            noteCategories.forEach { cat ->
+                            item {
+                                FilterChip(
+                                    selected = selectedCategory == null,
+                                    onClick = { vm.setSelectedCategory(null) },
+                                    label = {
+                                        Text(
+                                            stringResource(R.string.all_categories),
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    },
+                                )
+                            }
+                            items(noteCategories, key = { it }) { cat ->
                                 FilterChip(
                                     selected = selectedCategory == cat,
                                     onClick = { vm.toggleCategoryChip(cat) },

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
@@ -1,17 +1,20 @@
 package com.jotty.android.ui.notes
 
+import android.app.Application
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.ImageLoader
 import com.jotty.android.data.api.JottyApi
-import com.jotty.android.data.local.JottyDatabase
-import com.jotty.android.data.local.OfflineNotesRepository
 import com.jotty.android.data.preferences.SettingsRepository
-import kotlinx.coroutines.launch
 
 /**
  * Wrapper for NotesScreen that adds offline support.
  * Switches between online API calls and offline repository based on settings.
+ *
+ * [OfflineNotesViewModel] owns the [OfflineNotesRepository] so the network callback
+ * and coroutine scope are properly cleaned up in ViewModel.onCleared(), not leaked
+ * across recompositions.
  */
 @Composable
 fun OfflineNotesScreen(
@@ -23,24 +26,17 @@ fun OfflineNotesScreen(
     swipeToDeleteEnabled: Boolean = false,
     imageLoader: ImageLoader? = null,
 ) {
-    val context = LocalContext.current
+    val application = LocalContext.current.applicationContext as Application
+    val vm: OfflineNotesViewModel = viewModel(
+        key = instanceId,
+        factory = OfflineNotesViewModel.Factory(application, instanceId, api),
+    )
+    val offlineRepository = vm.repository
     val offlineModeEnabled by settingsRepository.offlineModeEnabled.collectAsState(initial = true)
-    
-    // Create offline repository (use applicationContext for lifecycle safety)
-    val offlineRepository = remember(instanceId) {
-        val appContext = context.applicationContext
-        val database = JottyDatabase.getDatabase(appContext)
-        OfflineNotesRepository(appContext, database, instanceId, api)
-    }
 
-    val scope = rememberCoroutineScope()
-    
-    // Initial sync when offline mode is enabled
     LaunchedEffect(offlineModeEnabled, instanceId) {
         if (offlineModeEnabled) {
-            scope.launch {
-                offlineRepository.syncNotes()
-            }
+            offlineRepository.syncNotes()
         }
     }
 
@@ -55,7 +51,6 @@ fun OfflineNotesScreen(
             imageLoader = imageLoader,
         )
     } else {
-        // Use original online-only screen
         NotesScreen(
             api = api,
             settingsRepository = settingsRepository,

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesViewModel.kt
@@ -1,0 +1,54 @@
+package com.jotty.android.ui.notes
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.JottyDatabase
+import com.jotty.android.data.local.OfflineNotesRepository
+
+/**
+ * Owns [OfflineNotesRepository] for the duration of the Notes destination.
+ *
+ * Using AndroidViewModel ties the repository's lifecycle to the ViewModel, which means
+ * [OfflineNotesRepository.close] (unregister network callback + cancel coroutine scope)
+ * is called when the user navigates away permanently or the process is destroyed —
+ * not on every recomposition.
+ *
+ * A new instance is created per [instanceId] via [Factory] and the `key` parameter of
+ * `viewModel()`. Changing instances destroys the old ViewModel (triggering close) and
+ * creates a fresh one.
+ *
+ * Known limitation (CLAUDE.md issue #7): if the API key is rotated for the same instance
+ * without changing the instance ID, [OfflineNotesRepository] keeps the stale [JottyApi]
+ * until the ViewModel is recreated. A proper fix requires either DI or a mutable api holder
+ * in the repository, but is left for a dedicated change to keep this diff focused.
+ */
+class OfflineNotesViewModel(
+    application: Application,
+    instanceId: String,
+    api: JottyApi,
+) : AndroidViewModel(application) {
+
+    val repository: OfflineNotesRepository = OfflineNotesRepository(
+        context = application,
+        database = JottyDatabase.getDatabase(application),
+        instanceId = instanceId,
+        api = api,
+    )
+
+    override fun onCleared() {
+        repository.close()
+    }
+
+    class Factory(
+        private val application: Application,
+        private val instanceId: String,
+        private val api: JottyApi,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T =
+            OfflineNotesViewModel(application, instanceId, api) as T
+    }
+}

--- a/app/src/test/java/com/jotty/android/data/local/NoteEntityTest.kt
+++ b/app/src/test/java/com/jotty/android/data/local/NoteEntityTest.kt
@@ -78,8 +78,9 @@ class NoteEntityTest {
 
         val entity = note.toEntity(instanceId = "instance-123")
 
-        assertEquals(false, entity.isDirty) // default when not specified
+        assertEquals(false, entity.isDirty)
         assertEquals(false, entity.isDeleted)
+        assertEquals(false, entity.isLocalOnly)
         assertEquals(null, entity.encrypted)
     }
 

--- a/app/src/test/java/com/jotty/android/data/local/OfflineNotesRepositoryTest.kt
+++ b/app/src/test/java/com/jotty/android/data/local/OfflineNotesRepositoryTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -259,6 +260,95 @@ class OfflineNotesRepositoryTest {
         assertTrue(result.isSuccess)
         assertFalse("createNote must not be called for an existing note", createCalled)
         assertTrue("updateNote should have been called", updateCalled)
+    }
+
+    @Test
+    fun syncNote_createOfflineThenEditOfflineThenSync_callsCreateNotUpdateNote() = runTest {
+        // Exact reproduction of the original bug:
+        // 1. createNote() offline  → isLocalOnly = true, createdAt == updatedAt
+        // 2. updateNote() offline  → updatedAt changes, but isLocalOnly stays true
+        // 3. syncNotes() online    → must call createNote, NOT updateNote
+        var createCalled = false
+        var updateCalled = false
+        val api = FakeJottyApi(
+            notesFromGet = emptyList(),
+            createNoteResponse = { req ->
+                createCalled = true
+                ApiResponse(
+                    true,
+                    Note("server-id", req.title, req.category ?: API_CATEGORY_UNCATEGORIZED, req.content.orEmpty(), "c", "u"),
+                )
+            },
+            updateNoteHandler = { _, _ ->
+                updateCalled = true
+                error("must not be called — note was never on the server")
+            },
+        )
+        // Start offline so neither createNote nor syncNote hits the server yet.
+        val repo = OfflineNotesRepository(
+            context = context,
+            database = database,
+            instanceId = instanceId,
+            api = api,
+            initialOnlineOverride = false,
+            registerNetworkCallback = false,
+        )
+
+        val createResult = repo.createNote(title = "Draft", content = "v1")
+        assertTrue(createResult.isSuccess)
+        val localId = createResult.getOrThrow().id
+
+        val editResult = repo.updateNote(localId, "Draft", "v2 edited offline", API_CATEGORY_UNCATEGORIZED)
+        assertTrue(editResult.isSuccess)
+
+        // Verify the note is still flagged local-only after the edit.
+        val entityAfterEdit = database.noteDao().getNoteById(localId)
+        assertTrue("isLocalOnly must survive offline edit", entityAfterEdit!!.isLocalOnly)
+
+        // Now go online and sync — must call createNote, never updateNote.
+        val syncResult = repo.syncNotes()
+        assertTrue(syncResult.isSuccess)
+        assertTrue("createNote must be called when syncing a local-only note", createCalled)
+        assertFalse("updateNote must not be called for a note never seen by the server", updateCalled)
+    }
+
+    @Test
+    fun deleteNote_whenLocalOnly_hardDeletesWithoutServerCall() = runTest {
+        var deleteCalled = false
+        val api = FakeJottyApi(
+            deleteNoteResult = { _ ->
+                deleteCalled = true
+                SuccessResponse(true)
+            },
+        )
+        val repo = OfflineNotesRepository(
+            context = context,
+            database = database,
+            instanceId = instanceId,
+            api = api,
+            initialOnlineOverride = true,
+            registerNetworkCallback = false,
+        )
+
+        val createResult = repo.createNote(title = "Local only", content = "")
+        assertTrue(createResult.isSuccess)
+        val localId = createResult.getOrThrow().id
+
+        // Pause sync so createNote stays pending (online but note not synced yet).
+        // Re-use a fresh repo with isOnline=false to isolate the delete path.
+        val offlineRepo = OfflineNotesRepository(
+            context = context,
+            database = database,
+            instanceId = instanceId,
+            api = api,
+            initialOnlineOverride = false,
+            registerNetworkCallback = false,
+        )
+        val deleteResult = offlineRepo.deleteNote(localId)
+
+        assertTrue(deleteResult.isSuccess)
+        assertFalse("server deleteNote must not be called for a local-only note", deleteCalled)
+        assertNull("note must be hard-deleted from DB", database.noteDao().getNoteById(localId))
     }
 
     @Test

--- a/app/src/test/java/com/jotty/android/data/local/OfflineNotesRepositoryTest.kt
+++ b/app/src/test/java/com/jotty/android/data/local/OfflineNotesRepositoryTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -169,6 +170,95 @@ class OfflineNotesRepositoryTest {
 
         assertEquals(1, conflictCopies.size)
         assertEquals("copy", conflictCopies.single().id)
+    }
+
+    @Test
+    fun syncNote_whenIsLocalOnly_callsCreateNoteNotUpdateNote() = runTest {
+        var createCalled = false
+        var updateCalled = false
+        val api = FakeJottyApi(
+            notesFromGet = emptyList(),
+            createNoteResponse = { req ->
+                createCalled = true
+                ApiResponse(
+                    true,
+                    Note("server-id", req.title, req.category ?: API_CATEGORY_UNCATEGORIZED, req.content.orEmpty(), "c", "u"),
+                )
+            },
+            updateNoteHandler = { _, _ ->
+                updateCalled = true
+                error("should not be called for a local-only note")
+            },
+        )
+        val repo = OfflineNotesRepository(
+            context = context,
+            database = database,
+            instanceId = instanceId,
+            api = api,
+            initialOnlineOverride = true,
+            registerNetworkCallback = false,
+        )
+
+        val result = repo.createNote(title = "Offline note", content = "body")
+
+        assertTrue(result.isSuccess)
+        assertTrue("createNote should have been called", createCalled)
+        assertFalse("updateNote must not be called for a local-only note", updateCalled)
+        // The temporary local ID must have been replaced by the server-assigned ID.
+        val stored = database.noteDao().getAllNotes(instanceId)
+        assertEquals(1, stored.size)
+        assertEquals("server-id", stored.single().id)
+        assertFalse("isLocalOnly must be cleared after successful server sync", stored.single().isLocalOnly)
+    }
+
+    @Test
+    fun syncNote_whenNotLocalOnly_callsUpdateNoteNotCreateNote() = runTest {
+        var createCalled = false
+        var updateCalled = false
+        val api = FakeJottyApi(
+            notesFromGet = emptyList(),
+            createNoteResponse = { _ ->
+                createCalled = true
+                error("should not be called for an existing note")
+            },
+            updateNoteHandler = { noteId, req ->
+                updateCalled = true
+                ApiResponse(
+                    true,
+                    Note(noteId, req.title, req.category ?: API_CATEGORY_UNCATEGORIZED, req.content.orEmpty(), "c", "u"),
+                )
+            },
+        )
+        // Pre-insert an existing (server-synced) note — isLocalOnly defaults to false.
+        database.noteDao().insertNote(
+            NoteEntity(
+                id = "existing-server-id",
+                title = "Old Title",
+                category = API_CATEGORY_UNCATEGORIZED,
+                content = "old body",
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-01-01T00:00:00Z",
+                encrypted = null,
+                isDirty = false,
+                isDeleted = false,
+                instanceId = instanceId,
+                isLocalOnly = false,
+            ),
+        )
+        val repo = OfflineNotesRepository(
+            context = context,
+            database = database,
+            instanceId = instanceId,
+            api = api,
+            initialOnlineOverride = true,
+            registerNetworkCallback = false,
+        )
+
+        val result = repo.updateNote("existing-server-id", "New Title", "new body", API_CATEGORY_UNCATEGORIZED)
+
+        assertTrue(result.isSuccess)
+        assertFalse("createNote must not be called for an existing note", createCalled)
+        assertTrue("updateNote should have been called", updateCalled)
     }
 
     @Test


### PR DESCRIPTION


---

## Fixes

### 1. `isLocalOnly` flag — correct offline sync routing

**Problem:** Creating a note offline then editing it before sync caused the note to be sent as `createNote` instead of `updateNote`, resulting in duplicates or silent data loss.

**Root cause:** The old heuristic `createdAt == updatedAt` to detect new notes breaks as soon as the note is edited offline (timestamps diverge).

**Fix:** Added `isLocalOnly: Boolean` column to `NoteEntity`. Set to `true` on offline creation, cleared to `false` after successful server sync. `deleteNote` now hard-deletes local-only notes without making a server call (avoids guaranteed 404).

Includes a DB migration (v1 → v2) with best-effort rescue of pre-existing dirty notes.

---

### 2. `OfflineNotesRepository` lifecycle — fix network callback + coroutine scope leak

**Problem:** `OfflineNotesRepository` registered a `ConnectivityManager.NetworkCallback` and held a `CoroutineScope`, but neither was ever released. Every navigation to the Notes screen leaked a callback registration and a live coroutine scope.

**Fix:** Added `close()` method (unregisters network callback, cancels coroutine scope, guarded by `@Volatile closed` flag). Introduced `OfflineNotesViewModel` (AndroidViewModel) to own the repository — `onCleared()` calls `close()`, tying cleanup to the ViewModel lifecycle rather than recomposition.

---

### 3. Scrollable category filter chips

**Problem:** Category chips were laid out in a non-scrollable `Row`, clipping any categories that don't fit on screen. `NotesScreen` worked around this with `.take(5)`, hiding all categories beyond the fifth.

**Fix:** Replaced both `Row { forEach }` usages with `LazyRow` (with `contentPadding` and `key`). Removed the `.take(5)` workaround — all categories are now reachable.

---