### PR TITLE
Release v1.3.4

### DIFF
--- a/.github/workflows/dev-latest.yml
+++ b/.github/workflows/dev-latest.yml
@@ -20,11 +20,71 @@ jobs:
 
       - uses: android-actions/setup-android@v4
 
-      - name: Build debug APK
+      - name: Read version name
+        id: ver
+        run: |
+          VERSION_NAME=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2-)
+          echo "VERSION_NAME=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+
+      # Same release keystore as stable releases so in-app dev updates install over v1.3.x stable.
+      - name: Decode release keystore
+        id: signing
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -e
+          if [ -z "$ANDROID_KEYSTORE_B64" ]; then
+            echo "have_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          for var in ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!var}" ]; then
+              echo "::error::ANDROID_KEYSTORE_B64 is set but $var is missing. Set all four signing secrets."
+              exit 1
+            fi
+          done
+          echo "$ANDROID_KEYSTORE_B64" | base64 -d > "$GITHUB_WORKSPACE/ci-release.keystore"
+          {
+            echo "storeFile=$GITHUB_WORKSPACE/ci-release.keystore"
+            echo "storePassword=$ANDROID_KEYSTORE_PASSWORD"
+            echo "keyAlias=$ANDROID_KEY_ALIAS"
+            echo "keyPassword=$ANDROID_KEY_PASSWORD"
+          } > keystore.properties
+          echo "have_release=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build release dev APK
+        if: steps.signing.outputs.have_release == 'true'
+        run: chmod +x gradlew && ./gradlew assembleRelease --no-daemon -PDEV_BUILD_SHA=${GITHUB_SHA}
+
+      - name: Build debug dev APK (no release keystore)
+        if: steps.signing.outputs.have_release != 'true'
         run: chmod +x gradlew && ./gradlew assembleDebug --no-daemon -PDEV_BUILD_SHA=${GITHUB_SHA}
 
-      - name: Rename debug APK for release asset
-        run: cp app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/jotty-android-debug.apk
+      - name: Prepare dev-latest asset
+        id: asset
+        run: |
+          VERSION="${{ steps.ver.outputs.VERSION_NAME }}"
+          if [ "${{ steps.signing.outputs.have_release }}" = "true" ]; then
+            OUT="jotty-android-${VERSION}-dev.apk"
+            cp app/build/outputs/apk/release/app-release.apk "$OUT"
+          else
+            OUT="jotty-android-${VERSION}-dev-debug.apk"
+            cp app/build/outputs/apk/debug/app-debug.apk "$OUT"
+          fi
+          echo "path=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Signing reminder (no release keystore)
+        if: steps.signing.outputs.have_release != 'true'
+        run: |
+          {
+            echo "## Dev APK signing"
+            echo ""
+            echo "No release keystore secrets were configured. Attached **debug-signed** dev APK."
+            echo "Users on **release-signed** stable installs may see **App not installed** when updating via the app."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Reset dev-latest release and tag
         env:
@@ -45,7 +105,7 @@ jobs:
             Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           prerelease: true
           makeLatest: false
-          artifacts: app/build/outputs/apk/debug/jotty-android-debug.apk
+          artifacts: ${{ steps.asset.outputs.path }}
           artifactErrorsFailBuild: true
           allowUpdates: false
           removeArtifacts: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 ## [Unreleased]
 
+---
+
+## [1.3.4] - 2026-05-24
+
 ### Fixed
 
 - **Dev in-app updates (“App not installed”)** — `dev-latest` CI now builds a **release-signed** dev APK (same keystore as stable) when secrets are configured; dev version suffix applies to release builds. Update checker prefers non-`debug` APK assets. Settings shows signing hints on the dev channel.
@@ -631,3 +635,5 @@ All notable changes to Jotty Android are documented here. The format is based on
 [1.0.2]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.0.2
 [1.0.1]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.0.1
 [1.0.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.0.0
+
+[1.3.4]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dev in-app updates (“App not installed”)** — `dev-latest` CI now builds a **release-signed** dev APK (same keystore as stable) when secrets are configured; dev version suffix applies to release builds. Update checker prefers non-`debug` APK assets. Settings shows signing hints on the dev channel.
+
 ---
 
 ## [1.3.3] - 2026-05-24

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Both scripts can prompt for a version (default is current patch + 1), increment 
 
 Manual fallback: update both values in `gradle.properties`, add an entry to **`CHANGELOG.md`**, then build and tag (e.g. `v1.0.1`).
 
+### Git: `dev-latest` tag conflicts on pull
+
+The rolling **`dev-latest`** tag moves on every push to `dev`. If `git pull --tags` reports `would clobber existing tag` for `dev-latest`, the branch still updated — only the tag was skipped.
+
+- **Day to day:** `git pull origin dev` (omit `--tags`).
+- **Refresh the local tag:** `.\scripts\sync-dev-latest-tag.ps1` (Windows) or `./scripts/sync-dev-latest-tag.sh` (Linux/macOS), or `git fetch origin tag dev-latest --force`.
+
 **Signed release APK:** Copy `keystore.properties.example` to `keystore.properties`, create a keystore (see the example file for the `keytool` command), then run `.\build.ps1 -Release`. The release APK will be signed and installable. Keep your keystore and passwords safe and never commit them.
 
 ## Building

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,11 +41,11 @@ android {
         }
     }
 
+    val devVersionSuffix = if (!devBuildSha.isNullOrBlank()) "-dev+$devBuildSha" else null
+
     buildTypes {
         getByName("debug") {
-            if (!devBuildSha.isNullOrBlank()) {
-                versionNameSuffix = "-dev+$devBuildSha"
-            }
+            devVersionSuffix?.let { versionNameSuffix = it }
         }
         release {
             isMinifyEnabled = true
@@ -56,6 +56,7 @@ android {
             if (keystorePropertiesFile.exists()) {
                 signingConfig = signingConfigs.getByName("release")
             }
+            devVersionSuffix?.let { versionNameSuffix = it }
         }
     }
 

--- a/app/src/main/java/com/jotty/android/data/updates/UpdateChecker.kt
+++ b/app/src/main/java/com/jotty/android/data/updates/UpdateChecker.kt
@@ -136,7 +136,7 @@ object UpdateChecker {
         val release = githubApi.getLatestRelease()
         val latestVersion = release.tagName.removePrefix("v").trim()
         val apkAsset =
-            release.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
+            preferredApkAsset(release.assets)
                 ?: return UpdateCheckResult.Error(context.getString(R.string.no_apk_in_release))
 
         val current = BuildConfig.VERSION_NAME?.trim() ?: "0.0.0"
@@ -155,7 +155,7 @@ object UpdateChecker {
     private suspend fun checkDevRelease(context: Context): UpdateCheckResult {
         val release = githubApi.getDevLatestRelease()
         val apkAsset =
-            release.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
+            preferredApkAsset(release.assets)
                 ?: return UpdateCheckResult.Error(context.getString(R.string.no_apk_in_release))
 
         val remoteCommit =
@@ -218,6 +218,13 @@ object UpdateChecker {
 
     private fun parseVersionParts(version: String): List<Int> {
         return version.split(".").map { it.filter { c -> c.isDigit() }.toIntOrNull() ?: 0 }.ifEmpty { listOf(0) }
+    }
+
+    /** Prefer release-signed APK assets over `*-debug.apk` when both are attached. */
+    internal fun preferredApkAsset(assets: List<GitHubAsset>): GitHubAsset? {
+        val apks = assets.filter { it.name.endsWith(".apk", ignoreCase = true) }
+        return apks.firstOrNull { !it.name.contains("-debug", ignoreCase = true) }
+            ?: apks.firstOrNull()
     }
 
     /**

--- a/app/src/main/java/com/jotty/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/settings/SettingsScreen.kt
@@ -687,6 +687,14 @@ private fun AboutDialog(
                         label = { Text(stringResource(R.string.update_channel_dev)) },
                     )
                 }
+                if (parsedChannel == UpdateChannel.Dev) {
+                    Text(
+                        text = stringResource(R.string.update_dev_channel_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
                 when (val state = updateState) {
                     UpdateUiState.Idle -> {
                         TextButton(
@@ -748,6 +756,7 @@ private fun AboutDialog(
                                     downloadUrl = r.downloadUrl,
                                     releaseNotes = r.releaseNotes,
                                     installFailedMessage = null,
+                                    showSigningHints = parsedChannel == UpdateChannel.Dev,
                                     onDownloadAndInstall = {
                                         scope.launch {
                                             updateState = UpdateUiState.Downloading
@@ -811,6 +820,7 @@ private fun AboutDialog(
                             downloadUrl = state.downloadUrl,
                             releaseNotes = state.releaseNotes,
                             installFailedMessage = state.userMessage,
+                            showSigningHints = true,
                             onDownloadAndInstall = {
                                 scope.launch {
                                     updateState = UpdateUiState.Downloading
@@ -863,6 +873,7 @@ private fun UpdateAvailableContent(
     downloadUrl: String,
     releaseNotes: String?,
     installFailedMessage: String?,
+    showSigningHints: Boolean = false,
     onDownloadAndInstall: () -> Unit,
     onOpenReleasePage: () -> Unit,
 ) {
@@ -872,6 +883,13 @@ private fun UpdateAvailableContent(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        if (showSigningHints) {
+            Text(
+                text = stringResource(R.string.update_signing_mismatch_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         releaseNotes?.takeIf { it.isNotBlank() }?.let { notes ->
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,8 @@
     <string name="update_version_dev_format">Dev %1$s</string>
     <string name="downloading">Downloading…</string>
     <string name="install_failed">%1$s. You can install from the release page.</string>
+    <string name="update_signing_mismatch_hint">If the installer says “App not installed”, the APK may be signed differently than your installed app (common when switching between stable and dev). Uninstall Jotty once, then install the new APK. Your Jotty server data is not affected.</string>
+    <string name="update_dev_channel_hint">Dev builds update from the dev-latest release. Use the same signing as stable for in-app updates; otherwise uninstall once before installing dev.</string>
     <string name="open_release_page">Open release page</string>
     <string name="whats_new">What\'s new</string>
     <string name="about_easter_egg_title">Well spotted</string>

--- a/app/src/test/java/com/jotty/android/data/updates/UpdateCheckerTest.kt
+++ b/app/src/test/java/com/jotty/android/data/updates/UpdateCheckerTest.kt
@@ -1,5 +1,6 @@
 package com.jotty.android.data.updates
 
+import com.jotty.android.data.updates.GitHubAsset
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -114,5 +115,21 @@ class UpdateCheckerTest {
         val remote = "1.3.0"
         val local = UpdateChecker.baseVersionNameWithoutDevSuffix("1.3.0-dev+abcdef0")
         assertFalse(UpdateChecker.isNewerVersion(remote, local))
+    }
+
+    @Test
+    fun `preferredApkAsset prefers release-signed over debug`() {
+        val assets =
+            listOf(
+                GitHubAsset("jotty-android-1.3.3-dev-debug.apk", "https://example.com/debug"),
+                GitHubAsset("jotty-android-1.3.3-dev.apk", "https://example.com/release"),
+            )
+        assertEquals("jotty-android-1.3.3-dev.apk", UpdateChecker.preferredApkAsset(assets)?.name)
+    }
+
+    @Test
+    fun `preferredApkAsset falls back to debug when only debug attached`() {
+        val assets = listOf(GitHubAsset("jotty-android-debug.apk", "https://example.com/debug"))
+        assertEquals("jotty-android-debug.apk", UpdateChecker.preferredApkAsset(assets)?.name)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # App version (single source of truth — bump when cutting a release)
-VERSION_NAME=1.3.3
-VERSION_CODE=26
+VERSION_NAME=1.3.4
+VERSION_CODE=27
 android.defaults.buildfeatures.resvalues=true
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.enableAppCompileTimeRClass=false

--- a/scripts/sync-dev-latest-tag.ps1
+++ b/scripts/sync-dev-latest-tag.ps1
@@ -1,0 +1,6 @@
+# Updates the local dev-latest tag from origin (safe when pull --tags fails with "would clobber").
+# dev-latest is a moving tag recreated by CI on every push to dev.
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+git fetch origin tag dev-latest --force
+Write-Host "Local tag dev-latest now matches origin."

--- a/scripts/sync-dev-latest-tag.sh
+++ b/scripts/sync-dev-latest-tag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Updates the local dev-latest tag from origin (safe when pull --tags fails with "would clobber").
+set -euo pipefail
+cd "$(dirname "$0")/.."
+git fetch origin tag dev-latest --force
+echo "Local tag dev-latest now matches origin."


### PR DESCRIPTION
## Summary

Patch after **v1.3.3** — fixes dev-channel in-app updates showing **App not installed** when stable and dev APKs used different signing keys.

- \dev-latest\ CI builds release-signed dev APKs (same keystore as stable)
- Update checker prefers non-debug APK assets; Settings signing hints
- \scripts/sync-dev-latest-tag.*\ + README for moving \dev-latest\ tag on \git pull --tags\

**Version:** 1.3.4 (VERSION_CODE 27)

After merge: tag \1.3.4\ and publish GitHub release.

Made with [Cursor](https://cursor.com)