### PR TITLE
Release v1.3.5

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,8 @@
+#!/bin/sh
+# After merge/pull on dev, keep local dev-latest tag aligned with origin (moving CI tag).
+branch=$(git symbolic-ref -q HEAD 2>/dev/null) || exit 0
+case "$branch" in
+  refs/heads/dev) ;;
+  *) exit 0 ;;
+esac
+git fetch origin tag dev-latest --force >/dev/null 2>&1 || true

--- a/.github/workflows/dev-latest.yml
+++ b/.github/workflows/dev-latest.yml
@@ -26,6 +26,15 @@ jobs:
           VERSION_NAME=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2-)
           echo "VERSION_NAME=$VERSION_NAME" >> "$GITHUB_OUTPUT"
 
+      # Monotonic versionCode per CI run so dev→dev in-app updates work when gradle VERSION_CODE is unchanged.
+      - name: Compute dev version code
+        id: devcode
+        run: |
+          BASE=$(grep '^VERSION_CODE=' gradle.properties | cut -d= -f2-)
+          DEV_CODE=$(( BASE * 10000 + GITHUB_RUN_NUMBER % 10000 ))
+          echo "code=$DEV_CODE" >> "$GITHUB_OUTPUT"
+          echo "Dev VERSION_CODE=$DEV_CODE (base=$BASE, run=$GITHUB_RUN_NUMBER)"
+
       # Same release keystore as stable releases so in-app dev updates install over v1.3.x stable.
       - name: Decode release keystore
         id: signing
@@ -57,11 +66,11 @@ jobs:
 
       - name: Build release dev APK
         if: steps.signing.outputs.have_release == 'true'
-        run: chmod +x gradlew && ./gradlew assembleRelease --no-daemon -PDEV_BUILD_SHA=${GITHUB_SHA}
+        run: chmod +x gradlew && ./gradlew assembleRelease --no-daemon -PDEV_BUILD_SHA=${GITHUB_SHA} -PVERSION_CODE=${{ steps.devcode.outputs.code }}
 
       - name: Build debug dev APK (no release keystore)
         if: steps.signing.outputs.have_release != 'true'
-        run: chmod +x gradlew && ./gradlew assembleDebug --no-daemon -PDEV_BUILD_SHA=${GITHUB_SHA}
+        run: chmod +x gradlew && ./gradlew assembleDebug --no-daemon -PDEV_BUILD_SHA=${GITHUB_SHA} -PVERSION_CODE=${{ steps.devcode.outputs.code }}
 
       - name: Prepare dev-latest asset
         id: asset

--- a/.github/workflows/sync-dev-with-main.yml
+++ b/.github/workflows/sync-dev-with-main.yml
@@ -1,0 +1,36 @@
+# After a release merges to main, fast-forward dev so both branches point at the same commit.
+# main accumulates "Merge pull request" commits; dev does not until this runs.
+name: Sync dev with main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward dev to main
+        run: |
+          set -e
+          git fetch origin main dev
+          if git rev-parse origin/dev >/dev/null 2>&1; then
+            if [ "$(git rev-parse origin/dev)" = "$(git rev-parse origin/main)" ]; then
+              echo "dev already matches main."
+              exit 0
+            fi
+          fi
+          if ! git merge-base --is-ancestor origin/dev origin/main 2>/dev/null; then
+            echo "::error::dev is not an ancestor of main — cannot fast-forward. Merge main into dev manually."
+            exit 1
+          fi
+          git push origin origin/main:refs/heads/dev
+          echo "dev fast-forwarded to $(git rev-parse --short origin/main)."

--- a/.release-notes-1.3.5.md
+++ b/.release-notes-1.3.5.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Git `dev-latest` tag on pull** — `scripts/setup-repo-git` adds a force-fetch refspec so `git pull --tags` no longer fails with “would clobber existing tag”; `scripts/pull-dev` runs setup and pulls `dev`. Optional `.githooks/post-merge` keeps the tag in sync on `dev` when `core.hooksPath` is set via setup.
+- **Dev in-app updates (“App not installed”)** — `dev-latest` CI assigns a monotonic `versionCode` per workflow run (same signing as stable when secrets are set). The app checks APK signing and version code before opening the installer and shows a clear message when the installed build was debug-signed or sideloaded with a different key.
+- **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide `NetworkConnectivityMonitor` (single network callback) so tab switches no longer desync Online/Offline; offline UI reads the shared online state. Sync runs when connectivity is restored. Homelab/LAN: online when `INTERNET` is available (not only `VALIDATED`); connectivity is re-checked when the app returns to foreground.
+- **Offline sync error display** — Reverse-proxy HTML (e.g. nginx `403 Forbidden`) is no longer shown in the UI; users see “Access denied” instead. Sync failures keep local offline items visible (snackbar + last-error row) instead of a full-screen error that hides them.
+
+### Changed
+
+- **Offline connectivity UX** — Prominent error banner and highlighted offline status when the server cannot be reached; **Try sync** on list and detail screens.
+- **Branch sync after release** — CI fast-forwards `dev` to `main` after each push to `main`, so release merge commits do not leave `main` ahead of `dev` with identical trees.
+
+**Full changelog:** https://github.com/Darknetzz/jotty-android/blob/main/CHANGELOG.md#135---2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+
+- **Branch sync after release** — CI fast-forwards `dev` to `main` after each push to `main`, so release merge commits do not leave `main` ahead of `dev` with identical trees.
+
 ---
 
 ## [1.3.4] - 2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 - **Dev in-app updates (“App not installed”)** — `dev-latest` CI assigns a monotonic `versionCode` per workflow run (same signing as stable when secrets are set). The app checks APK signing and version code before opening the installer and shows a clear message when the installed build was debug-signed or sideloaded with a different key.
 - **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide connectivity monitor (single network callback) so tab switches no longer desync Online/Offline. Sync runs when connectivity is restored.
+- **Offline sync error display** — Reverse-proxy HTML (e.g. nginx `403 Forbidden`) is no longer shown in the UI; users see “Access denied” instead. Sync failures keep local offline items visible (snackbar + last-error row) instead of a full-screen error that hides them.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dev in-app updates (“App not installed”)** — `dev-latest` CI assigns a monotonic `versionCode` per workflow run (same signing as stable when secrets are set). The app checks APK signing and version code before opening the installer and shows a clear message when the installed build was debug-signed or sideloaded with a different key.
+- **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide connectivity monitor (single network callback) so tab switches no longer desync Online/Offline. Sync runs when connectivity is restored.
+
 ### Changed
 
+- **Offline connectivity UX** — Prominent error banner and highlighted offline status when the server cannot be reached; **Try sync** on list and detail screens.
 - **Branch sync after release** — CI fast-forwards `dev` to `main` after each push to `main`, so release merge commits do not leave `main` ahead of `dev` with identical trees.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 ### Fixed
 
+- **Git `dev-latest` tag on pull** — `scripts/setup-repo-git` adds a force-fetch refspec so `git pull --tags` no longer fails with “would clobber existing tag”; `scripts/pull-dev` runs setup and pulls `dev`. Optional `.githooks/post-merge` keeps the tag in sync on `dev` when `core.hooksPath` is set via setup.
+
 - **Dev in-app updates (“App not installed”)** — `dev-latest` CI assigns a monotonic `versionCode` per workflow run (same signing as stable when secrets are set). The app checks APK signing and version code before opening the installer and shows a clear message when the installed build was debug-signed or sideloaded with a different key.
 - **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide connectivity monitor (single network callback) so tab switches no longer desync Online/Offline. Sync runs when connectivity is restored.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to Jotty Android are documented here. The format is based on
 
 ## [Unreleased]
 
+---
+
+## [1.3.5] - 2026-05-24
+
 ### Fixed
 
 - **Git `dev-latest` tag on pull** — `scripts/setup-repo-git` adds a force-fetch refspec so `git pull --tags` no longer fails with “would clobber existing tag”; `scripts/pull-dev` runs setup and pulls `dev`. Optional `.githooks/post-merge` keeps the tag in sync on `dev` when `core.hooksPath` is set via setup.
 
 - **Dev in-app updates (“App not installed”)** — `dev-latest` CI assigns a monotonic `versionCode` per workflow run (same signing as stable when secrets are set). The app checks APK signing and version code before opening the installer and shows a clear message when the installed build was debug-signed or sideloaded with a different key.
-- **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide connectivity monitor (single network callback) so tab switches no longer desync Online/Offline. Sync runs when connectivity is restored.
+- **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide `NetworkConnectivityMonitor` (single network callback) so tab switches no longer desync Online/Offline; offline UI reads the shared online state. Sync runs when connectivity is restored. Homelab/LAN: online when `INTERNET` is available (not only `VALIDATED`); connectivity is re-checked when the app returns to foreground.
 - **Offline sync error display** — Reverse-proxy HTML (e.g. nginx `403 Forbidden`) is no longer shown in the UI; users see “Access denied” instead. Sync failures keep local offline items visible (snackbar + last-error row) instead of a full-screen error that hides them.
 
 ### Changed
@@ -650,3 +654,5 @@ All notable changes to Jotty Android are documented here. The format is based on
 [1.0.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.0.0
 
 [1.3.4]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.3.4
+
+[1.3.5]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.3.5

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Preferred flow (automated):
 
 Both scripts can prompt for a version (default is current patch + 1), increment `VERSION_CODE`, and promote `CHANGELOG.md` from `Unreleased` to a dated release entry.
 
+**Typical stable release flow**
+
+1. Commit release prep on **`dev`** (`.\release.ps1`, then commit `gradle.properties` + `CHANGELOG.md`).
+2. Push **`dev`**, open a PR **`dev` → `main`**, merge (required by branch protection).
+3. Tag **`vX.Y.Z`** on **`main`** and publish the GitHub release (triggers the release APK workflow).
+4. **`dev` is synced to `main`** automatically by [sync-dev-with-main.yml](.github/workflows/sync-dev-with-main.yml) (fast-forward so both branches match — `main` would otherwise stay “ahead” with merge commits only).
+
+Manual sync if needed: `.\scripts\sync-dev-with-main.ps1` or `./scripts/sync-dev-with-main.sh`.
+
 Manual fallback: update both values in `gradle.properties`, add an entry to **`CHANGELOG.md`**, then build and tag (e.g. `v1.0.1`).
 
 ### Git: `dev-latest` tag conflicts on pull

--- a/README.md
+++ b/README.md
@@ -85,10 +85,31 @@ Manual fallback: update both values in `gradle.properties`, add an entry to **`C
 
 ### Git: `dev-latest` tag conflicts on pull
 
-The rolling **`dev-latest`** tag moves on every push to `dev`. If `git pull --tags` reports `would clobber existing tag` for `dev-latest`, the branch still updated — only the tag was skipped.
+The rolling **`dev-latest`** tag moves on every push to `dev`. Without setup, `git pull --tags` may report `would clobber existing tag` for `dev-latest` (the branch still updates; only the tag is skipped).
 
-- **Day to day:** `git pull origin dev` (omit `--tags`).
-- **Refresh the local tag:** `.\scripts\sync-dev-latest-tag.ps1` (Windows) or `./scripts/sync-dev-latest-tag.sh` (Linux/macOS), or `git fetch origin tag dev-latest --force`.
+**One-time per clone** (fixes `git pull --tags` permanently for this repo):
+
+```powershell
+.\scripts\setup-repo-git.ps1
+```
+
+```bash
+./scripts/setup-repo-git.sh
+```
+
+That adds a `+refs/tags/dev-latest` fetch refspec so Git force-updates the local tag instead of refusing.
+
+**Day to day:**
+
+```powershell
+.\scripts\pull-dev.ps1
+```
+
+```bash
+./scripts/pull-dev.sh
+```
+
+Or, after setup: `git pull --tags origin dev`. To refresh only the tag: `.\scripts\sync-dev-latest-tag.ps1` / `./scripts/sync-dev-latest-tag.sh`.
 
 **Signed release APK:** Copy `keystore.properties.example` to `keystore.properties`, create a keystore (see the example file for the `keytool` command), then run `.\build.ps1 -Release`. The release APK will be signed and installable. Keep your keystore and passwords safe and never commit them.
 

--- a/app/src/main/java/com/jotty/android/JottyApp.kt
+++ b/app/src/main/java/com/jotty/android/JottyApp.kt
@@ -21,6 +21,10 @@ class JottyApp : Application() {
         }
         ProcessLifecycleOwner.get().lifecycle.addObserver(
             object : androidx.lifecycle.DefaultLifecycleObserver {
+                override fun onStart(owner: androidx.lifecycle.LifecycleOwner) {
+                    NetworkConnectivityMonitor.refreshIfStarted(this@JottyApp)
+                }
+
                 override fun onStop(owner: androidx.lifecycle.LifecycleOwner) {
                     NoteDecryptionSession.clear()
                 }

--- a/app/src/main/java/com/jotty/android/JottyApp.kt
+++ b/app/src/main/java/com/jotty/android/JottyApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.jotty.android.data.encryption.NoteDecryptionSession
+import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.preferences.SettingsRepository
 import com.jotty.android.util.AppLog
 import kotlinx.coroutines.flow.first
@@ -14,6 +15,7 @@ class JottyApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        NetworkConnectivityMonitor.ensureStarted(this)
         ProcessLifecycleOwner.get().lifecycleScope.launch {
             settingsRepository.debugLoggingEnabled.first().let { AppLog.setDebugEnabled(it) }
         }

--- a/app/src/main/java/com/jotty/android/data/local/NetworkConnectivityMonitor.kt
+++ b/app/src/main/java/com/jotty/android/data/local/NetworkConnectivityMonitor.kt
@@ -1,0 +1,98 @@
+package com.jotty.android.data.local
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import com.jotty.android.util.AppLog
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * App-wide network connectivity (single [ConnectivityManager.NetworkCallback]).
+ * Offline notes and checklists repositories subscribe so tab switches do not
+ * register competing callbacks and desync "Online" / "Offline" state ([#27]).
+ */
+object NetworkConnectivityMonitor {
+    private const val TAG = "ConnectivityMonitor"
+
+    private val _isOnline = MutableStateFlow(false)
+    val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    @Volatile
+    private var started = false
+
+    private var connectivityManager: ConnectivityManager? = null
+
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    @Synchronized
+    fun ensureStarted(context: Context) {
+        if (started) return
+        val appContext = context.applicationContext
+        val cm = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        connectivityManager = cm
+        refreshOnlineState(appContext, reason = "init")
+
+        val callback =
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    refreshOnlineState(appContext, reason = "onAvailable")
+                }
+
+                override fun onLost(network: Network) {
+                    refreshOnlineState(appContext, reason = "onLost")
+                }
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    networkCapabilities: NetworkCapabilities,
+                ) {
+                    refreshOnlineState(appContext, reason = "onCapabilitiesChanged")
+                }
+            }
+        networkCallback = callback
+        cm?.registerDefaultNetworkCallback(callback)
+        started = true
+        AppLog.d(TAG, "Default network callback registered (online=${_isOnline.value})")
+    }
+
+    fun checkConnectivity(context: Context): Boolean {
+        val cm =
+            context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+                as? ConnectivityManager
+                ?: return false
+        val network = cm.activeNetwork ?: return false
+        val capabilities = cm.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    private fun refreshOnlineState(
+        context: Context,
+        reason: String,
+    ) {
+        val online = checkConnectivity(context)
+        if (_isOnline.value != online) {
+            AppLog.d(TAG, "Connectivity $reason -> online=$online")
+            _isOnline.value = online
+        }
+    }
+
+    /** Visible for tests. */
+    @Synchronized
+    internal fun resetForTests() {
+        networkCallback?.let { cb ->
+            runCatching { connectivityManager?.unregisterNetworkCallback(cb) }
+        }
+        networkCallback = null
+        connectivityManager = null
+        started = false
+        _isOnline.value = false
+    }
+
+    internal fun setOnlineForTests(value: Boolean) {
+        _isOnline.value = value
+    }
+}

--- a/app/src/main/java/com/jotty/android/data/local/NetworkConnectivityMonitor.kt
+++ b/app/src/main/java/com/jotty/android/data/local/NetworkConnectivityMonitor.kt
@@ -65,8 +65,15 @@ object NetworkConnectivityMonitor {
                 ?: return false
         val network = cm.activeNetwork ?: return false
         val capabilities = cm.getNetworkCapabilities(network) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        // INTERNET only (not VALIDATED): LAN / self-hosted servers often have INTERNET but
+        // stay "unvalidated" briefly or on split DNS; sync errors surface separately.
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    /** Re-check when the app returns to foreground (e.g. after toggling Wi‑Fi). */
+    fun refreshIfStarted(context: Context) {
+        if (!started) return
+        refreshOnlineState(context.applicationContext, reason = "refresh")
     }
 
     private fun refreshOnlineState(

--- a/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
@@ -44,7 +44,7 @@ class OfflineChecklistsRepository(
     private val instanceId: String,
     private val api: JottyApi,
     initialOnlineOverride: Boolean? = null,
-    private val registerNetworkCallback: Boolean = true,
+    private val useSharedConnectivity: Boolean = true,
 ) {
     private val appContext = context.applicationContext
     private val checklistDao = database.checklistDao()
@@ -55,7 +55,7 @@ class OfflineChecklistsRepository(
         OfflineRepositoryLifecycle(
             context = context,
             initialOnlineOverride = initialOnlineOverride,
-            registerNetworkCallback = registerNetworkCallback,
+            useSharedConnectivity = useSharedConnectivity,
             logTag = TAG,
             instanceId = instanceId,
             onNetworkAvailable = { syncChecklists() },

--- a/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
@@ -51,6 +51,7 @@ class OfflineChecklistsRepository(
     private val checklistDao = database.checklistDao()
     private val itemMutationDepth = AtomicInteger(0)
     private val pendingSyncAfterMutations = AtomicBoolean(false)
+
     @Volatile private var lastSyncCompletedAtMs: Long? = null
     private val runtime =
         OfflineRepositoryLifecycle(
@@ -175,23 +176,23 @@ class OfflineChecklistsRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 withItemMutation {
-                if (isOnline.value) {
-                    val response =
-                        api.addChecklistItem(
-                            checklistId,
-                            AddItemRequest(text = text, parentIndex = parentIndex),
-                        )
-                    // Refresh local cache from server
-                    val fresh = api.getChecklists().checklists.find { it.id == checklistId }
-                    if (fresh != null) checklistDao.insert(fresh.toEntity(instanceId))
-                    response.let {
-                        checklistDao.getById(checklistId)?.toChecklist()
-                            ?: throw Exception("Checklist not found")
+                    if (isOnline.value) {
+                        val response =
+                            api.addChecklistItem(
+                                checklistId,
+                                AddItemRequest(text = text, parentIndex = parentIndex),
+                            )
+                        // Refresh local cache from server
+                        val fresh = api.getChecklists().checklists.find { it.id == checklistId }
+                        if (fresh != null) checklistDao.insert(fresh.toEntity(instanceId))
+                        response.let {
+                            checklistDao.getById(checklistId)?.toChecklist()
+                                ?: throw Exception("Checklist not found")
+                        }
+                    } else {
+                        val op = PendingItemOp(type = "ADD", text = text, parentIndex = parentIndex)
+                        applyOpLocally(checklistId, op)
                     }
-                } else {
-                    val op = PendingItemOp(type = "ADD", text = text, parentIndex = parentIndex)
-                    applyOpLocally(checklistId, op)
-                }
                 }
             }
         }
@@ -203,12 +204,12 @@ class OfflineChecklistsRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 withItemMutation {
-                if (isOnline.value) {
-                    api.checkItem(checklistId, path)
-                    refreshFromServer(checklistId)
-                } else {
-                    applyOpLocally(checklistId, PendingItemOp(type = "CHECK", path = path))
-                }
+                    if (isOnline.value) {
+                        api.checkItem(checklistId, path)
+                        refreshFromServer(checklistId)
+                    } else {
+                        applyOpLocally(checklistId, PendingItemOp(type = "CHECK", path = path))
+                    }
                 }
             }
         }
@@ -220,12 +221,12 @@ class OfflineChecklistsRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 withItemMutation {
-                if (isOnline.value) {
-                    api.uncheckItem(checklistId, path)
-                    refreshFromServer(checklistId)
-                } else {
-                    applyOpLocally(checklistId, PendingItemOp(type = "UNCHECK", path = path))
-                }
+                    if (isOnline.value) {
+                        api.uncheckItem(checklistId, path)
+                        refreshFromServer(checklistId)
+                    } else {
+                        applyOpLocally(checklistId, PendingItemOp(type = "UNCHECK", path = path))
+                    }
                 }
             }
         }
@@ -237,12 +238,12 @@ class OfflineChecklistsRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 withItemMutation {
-                if (isOnline.value) {
-                    api.deleteItem(checklistId, path)
-                    refreshFromServer(checklistId)
-                } else {
-                    applyOpLocally(checklistId, PendingItemOp(type = "DELETE", path = path))
-                }
+                    if (isOnline.value) {
+                        api.deleteItem(checklistId, path)
+                        refreshFromServer(checklistId)
+                    } else {
+                        applyOpLocally(checklistId, PendingItemOp(type = "DELETE", path = path))
+                    }
                 }
             }
         }
@@ -255,15 +256,15 @@ class OfflineChecklistsRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 withItemMutation {
-                if (isOnline.value) {
-                    api.updateItem(checklistId, path, UpdateItemRequest(text = text))
-                    refreshFromServer(checklistId)
-                } else {
-                    applyOpLocally(
-                        checklistId,
-                        PendingItemOp(type = "UPDATE_TEXT", path = path, text = text),
-                    )
-                }
+                    if (isOnline.value) {
+                        api.updateItem(checklistId, path, UpdateItemRequest(text = text))
+                        refreshFromServer(checklistId)
+                    } else {
+                        applyOpLocally(
+                            checklistId,
+                            PendingItemOp(type = "UPDATE_TEXT", path = path, text = text),
+                        )
+                    }
                 }
             }
         }
@@ -389,8 +390,9 @@ class OfflineChecklistsRepository(
                 runCatching { api.addChecklistItem(created.id, AddItemRequest(text = item.text)) }
             }
             checklistDao.delete(entity.id)
-            val fresh = api.getChecklists().checklists.find { it.id == created.id }
-                ?: throw Exception("Checklist not found after create")
+            val fresh =
+                api.getChecklists().checklists.find { it.id == created.id }
+                    ?: throw Exception("Checklist not found after create")
             checklistDao.insert(fresh.toEntity(instanceId))
             AppLog.d(TAG, "Local-only checklist pushed: ${created.id}")
         } else {

--- a/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineChecklistsRepository.kt
@@ -10,6 +10,7 @@ import com.jotty.android.data.api.CreateChecklistRequest
 import com.jotty.android.data.api.JottyApi
 import com.jotty.android.data.api.UpdateChecklistRequest
 import com.jotty.android.data.api.UpdateItemRequest
+import com.jotty.android.util.ApiErrorHelper
 import com.jotty.android.util.AppLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -353,9 +354,10 @@ class OfflineChecklistsRepository(
                 AppLog.d(TAG, "Sync complete — ${serverChecklists.size} checklists from server")
                 Result.success(Unit)
             } catch (e: Exception) {
-                runtime.syncStatus.markSyncCompleted(success = false, errorMessage = e.message)
-                AppLog.d(TAG, "Sync failed: ${e.message}")
-                Result.failure(e)
+                val msg = ApiErrorHelper.userMessage(appContext, e)
+                runtime.syncStatus.markSyncCompleted(success = false, errorMessage = msg)
+                AppLog.d(TAG, "Sync failed: $msg")
+                Result.failure(Exception(msg, e))
             } finally {
                 runtime.syncStatus.setSyncing(false)
             }

--- a/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
@@ -7,6 +7,7 @@ import com.jotty.android.data.api.CreateNoteRequest
 import com.jotty.android.data.api.JottyApi
 import com.jotty.android.data.api.Note
 import com.jotty.android.data.api.UpdateNoteRequest
+import com.jotty.android.util.ApiErrorHelper
 import com.jotty.android.util.AppLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -305,10 +306,11 @@ class OfflineNotesRepository(
                 AppLog.d("OfflineNotesRepository", "Sync complete")
                 Result.success(Unit)
             } catch (e: Exception) {
-                runtime.syncStatus.markSyncCompleted(success = false, errorMessage = e.message)
+                val msg = ApiErrorHelper.userMessage(appContext, e)
+                runtime.syncStatus.markSyncCompleted(success = false, errorMessage = msg)
                 runtime.syncStatus.setSyncing(false)
-                AppLog.d("OfflineNotesRepository", "Sync failed: ${e.message}")
-                Result.failure(e)
+                AppLog.d("OfflineNotesRepository", "Sync failed: $msg")
+                Result.failure(Exception(msg, e))
             }
         }
 

--- a/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineNotesRepository.kt
@@ -28,7 +28,7 @@ class OfflineNotesRepository(
     /** When non-null, used instead of [checkConnectivity] for initial online state (e.g. unit tests). */
     initialOnlineOverride: Boolean? = null,
     /** Set false in tests to avoid registering a network callback. */
-    private val registerNetworkCallback: Boolean = true,
+    private val useSharedConnectivity: Boolean = true,
 ) {
     private val appContext = context.applicationContext
     private val noteDao = database.noteDao()
@@ -36,7 +36,7 @@ class OfflineNotesRepository(
         OfflineRepositoryLifecycle(
             context = context,
             initialOnlineOverride = initialOnlineOverride,
-            registerNetworkCallback = registerNetworkCallback,
+            useSharedConnectivity = useSharedConnectivity,
             logTag = TAG,
             instanceId = instanceId,
             onNetworkAvailable = { syncNotes() },

--- a/app/src/main/java/com/jotty/android/data/local/OfflineRepositoryRuntime.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineRepositoryRuntime.kt
@@ -1,14 +1,11 @@
 package com.jotty.android.data.local
 
 import android.content.Context
-import android.net.ConnectivityManager
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import com.jotty.android.util.AppLog
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -89,7 +86,7 @@ class SyncStatusState(initialOnline: Boolean) {
 class OfflineRepositoryLifecycle(
     private val context: Context,
     initialOnlineOverride: Boolean?,
-    private val registerNetworkCallback: Boolean,
+    private val useSharedConnectivity: Boolean,
     private val logTag: String,
     private val instanceId: String,
     private val onNetworkAvailable: suspend () -> Unit,
@@ -100,59 +97,55 @@ class OfflineRepositoryLifecycle(
         }
 
     val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + scopeExceptionHandler)
-    val syncStatus = SyncStatusState(initialOnlineOverride ?: checkConnectivity())
 
-    private val connectivityManager =
-        context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+    private val appContext = context.applicationContext
 
-    @Volatile private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    val syncStatus =
+        SyncStatusState(
+            initialOnlineOverride
+                ?: if (useSharedConnectivity) {
+                    NetworkConnectivityMonitor.checkConnectivity(appContext)
+                } else {
+                    false
+                },
+        )
 
-    @Volatile private var closed = false
+    private var connectivityJob: Job? = null
+
+    @Volatile
+    private var closed = false
 
     init {
-        if (registerNetworkCallback) {
-            connectivityManager?.let { cm ->
-                val networkRequest =
-                    NetworkRequest.Builder()
-                        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                        .build()
-                val callback =
-                    object : ConnectivityManager.NetworkCallback() {
-                        override fun onAvailable(network: Network) {
-                            if (closed) return
-                            AppLog.d(logTag, "Network available")
-                            syncStatus.setOnline(true)
-                            coroutineScope.launch { onNetworkAvailable() }
-                        }
-
-                        override fun onLost(network: Network) {
-                            if (closed) return
-                            AppLog.d(logTag, "Network lost")
-                            syncStatus.setOnline(false)
-                        }
-                    }
-                networkCallback = callback
-                cm.registerNetworkCallback(networkRequest, callback)
-                AppLog.d(logTag, "Network callback registered (instance: $instanceId)")
+        if (useSharedConnectivity) {
+            NetworkConnectivityMonitor.ensureStarted(appContext)
+            var wasOnline = syncStatus.isOnline.value
+            if (wasOnline) {
+                coroutineScope.launch { onNetworkAvailable() }
             }
+            connectivityJob =
+                coroutineScope.launch {
+                    NetworkConnectivityMonitor.isOnline.collect { online ->
+                        if (closed) return@collect
+                        syncStatus.setOnline(online)
+                        if (online && !wasOnline) {
+                            AppLog.d(logTag, "Connectivity restored — scheduling sync (instance: $instanceId)")
+                            onNetworkAvailable()
+                        }
+                        wasOnline = online
+                    }
+                }
+            AppLog.d(logTag, "Subscribed to shared connectivity (instance: $instanceId, online=$wasOnline)")
+        } else if (initialOnlineOverride != null) {
+            syncStatus.setOnline(initialOnlineOverride)
         }
     }
 
     fun close() {
         if (closed) return
         closed = true
-        networkCallback?.let {
-            connectivityManager?.unregisterNetworkCallback(it)
-            networkCallback = null
-        }
+        connectivityJob?.cancel()
+        connectivityJob = null
         coroutineScope.cancel()
         AppLog.d(logTag, "Closed (instance: $instanceId)")
-    }
-
-    private fun checkConnectivity(): Boolean {
-        val cm = connectivityManager ?: return false
-        val network = cm.activeNetwork ?: return false
-        val capabilities = cm.getNetworkCapabilities(network) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 }

--- a/app/src/main/java/com/jotty/android/data/updates/UpdateChecker.kt
+++ b/app/src/main/java/com/jotty/android/data/updates/UpdateChecker.kt
@@ -8,6 +8,7 @@ import androidx.core.content.FileProvider
 import com.jotty.android.BuildConfig
 import com.jotty.android.R
 import com.jotty.android.util.ApiErrorHelper
+import com.jotty.android.util.ApkInstallHelper
 import com.jotty.android.util.AppLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -282,6 +283,14 @@ object UpdateChecker {
         context: Context,
         apkFile: File,
     ): InstallResult {
+        if (!ApkInstallHelper.canInstallOverExisting(context, apkFile)) {
+            AppLog.w(TAG, "Update APK signing does not match installed app")
+            return InstallResult.Failed(context.getString(R.string.update_signing_mismatch_blocked))
+        }
+        if (!ApkInstallHelper.isVersionCodeAllowedForUpdate(context, apkFile)) {
+            AppLog.w(TAG, "Update APK versionCode is lower than installed app")
+            return InstallResult.Failed(context.getString(R.string.update_version_downgrade_blocked))
+        }
         return try {
             val uri: Uri =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -304,6 +313,7 @@ object UpdateChecker {
                         addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
                     }
                 }
+            ApkInstallHelper.grantReadPermissionToInstallers(context, uri, intent)
             context.startActivity(intent)
             InstallResult.Started
         } catch (e: Exception) {

--- a/app/src/main/java/com/jotty/android/ui/checklists/ChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/ChecklistsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Delete

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsScreen.kt
@@ -28,9 +28,12 @@ fun OfflineChecklistsScreen(
         )
     val offlineRepository = vm.repository
     val offlineModeEnabled by settingsRepository.offlineModeEnabled.collectAsStateWithLifecycle(initialValue = true)
+    val isOnline by offlineRepository.isOnline.collectAsStateWithLifecycle()
 
-    LaunchedEffect(offlineModeEnabled, instanceId, authFingerprint) {
-        if (offlineModeEnabled) offlineRepository.syncChecklists()
+    LaunchedEffect(offlineModeEnabled, instanceId, authFingerprint, isOnline) {
+        if (offlineModeEnabled && isOnline) {
+            offlineRepository.syncChecklists()
+        }
     }
 
     if (offlineModeEnabled) {

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineChecklistsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.preferences.SettingsRepository
 
 /**
@@ -28,7 +29,7 @@ fun OfflineChecklistsScreen(
         )
     val offlineRepository = vm.repository
     val offlineModeEnabled by settingsRepository.offlineModeEnabled.collectAsStateWithLifecycle(initialValue = true)
-    val isOnline by offlineRepository.isOnline.collectAsStateWithLifecycle()
+    val isOnline by NetworkConnectivityMonitor.isOnline.collectAsStateWithLifecycle()
 
     LaunchedEffect(offlineModeEnabled, instanceId, authFingerprint, isOnline) {
         if (offlineModeEnabled && isOnline) {

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
@@ -33,6 +33,7 @@ import com.jotty.android.R
 import com.jotty.android.data.api.Checklist
 import com.jotty.android.data.api.ChecklistItem
 import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.local.OfflineChecklistsRepository
 import com.jotty.android.data.preferences.SettingsRepository
 import com.jotty.android.ui.common.ConfirmDeleteDialog
@@ -66,7 +67,7 @@ fun OfflineEnabledChecklistsScreen(
         }
 
     val checklists by offlineRepository.getChecklistsFlow().collectAsStateWithLifecycle(initialValue = emptyList())
-    val isOnline by offlineRepository.isOnline.collectAsStateWithLifecycle()
+    val isOnline by NetworkConnectivityMonitor.isOnline.collectAsStateWithLifecycle()
     val isSyncing by offlineRepository.isSyncing.collectAsStateWithLifecycle()
     val conflictsDetected by offlineRepository.conflictsDetected.collectAsStateWithLifecycle()
     val replayFailuresDetected by offlineRepository.replayFailuresDetected.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
@@ -40,6 +40,7 @@ import com.jotty.android.ui.common.DeleteDropdownMenuItem
 import com.jotty.android.ui.common.EditDropdownMenuItem
 import com.jotty.android.ui.common.ListScreenContent
 import com.jotty.android.ui.common.MainNestedScaffoldContentWindowInsets
+import com.jotty.android.ui.common.OfflineConnectivityBanner
 import com.jotty.android.ui.common.OfflineSyncStatusRow
 import com.jotty.android.ui.common.SwipeToDeleteContainer
 import com.jotty.android.ui.common.mainScreenTabContentPadding
@@ -204,6 +205,7 @@ fun OfflineEnabledChecklistsScreen(
                     checklist = currentList,
                     offlineRepository = offlineRepository,
                     isOnline = isOnline,
+                    onRetrySync = { requestSync(showLoading = true) },
                     onBack = { vm.setSelectedList(null) },
                     onUpdate = { vm.setSelectedList(it) },
                     onDelete = {
@@ -221,7 +223,11 @@ fun OfflineEnabledChecklistsScreen(
                     onSavedLocally = { scope.launch { snackbarHostState.showSnackbar(savedLocallyMsg) } },
                 )
             } else {
-                // Header row: status + actions
+                OfflineConnectivityBanner(
+                    isOnline = isOnline,
+                    onRetrySync = { requestSync(showLoading = true) },
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
                 OfflineSyncStatusRow(
                     isOnline = isOnline,
                     isSyncing = isSyncing,
@@ -509,6 +515,7 @@ private fun OfflineChecklistDetailContent(
     checklist: Checklist,
     offlineRepository: OfflineChecklistsRepository,
     isOnline: Boolean,
+    onRetrySync: () -> Unit,
     onBack: () -> Unit,
     onUpdate: (Checklist) -> Unit,
     onDelete: () -> Unit,
@@ -561,6 +568,12 @@ private fun OfflineChecklistDetailContent(
             onBack = onBack,
             onRename = { showRenameDialog = true },
             onDelete = onDelete,
+        )
+
+        OfflineConnectivityBanner(
+            isOnline = isOnline,
+            onRetrySync = onRetrySync,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/checklists/OfflineEnabledChecklistsScreen.kt
@@ -144,11 +144,16 @@ fun OfflineEnabledChecklistsScreen(
             screenState.errorMessage = null
             val result = offlineRepository.syncChecklists(force = showLoading)
             if (result.isFailure) {
-                screenState.errorMessage =
+                val msg =
                     ApiErrorHelper.userMessage(
                         context,
                         result.exceptionOrNull() ?: Exception("Sync failed"),
                     )
+                if (checklists.isEmpty()) {
+                    screenState.errorMessage = msg
+                } else {
+                    snackbarHostState.showSnackbar(msg)
+                }
             }
             if (showLoading) screenState.loading = false
         }

--- a/app/src/main/java/com/jotty/android/ui/common/ListScreenComponents.kt
+++ b/app/src/main/java/com/jotty/android/ui/common/ListScreenComponents.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.CloudQueue
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -59,6 +60,60 @@ fun LoadingState(
     }
 }
 
+/** Prominent warning when the app cannot reach the server (shared connectivity monitor). */
+@Composable
+fun OfflineConnectivityBanner(
+    isOnline: Boolean,
+    onRetrySync: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (isOnline) return
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Default.WifiOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(28.dp),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.connectivity_not_established_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.connectivity_not_established_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+            TextButton(onClick = onRetrySync) {
+                Text(
+                    stringResource(R.string.connectivity_retry_sync),
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        }
+    }
+}
+
 @Composable
 fun OfflineSyncStatusRow(
     isOnline: Boolean,
@@ -80,9 +135,23 @@ fun OfflineSyncStatusRow(
                 DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(it))
             }
         }
+    val offline = !isOnline && !isSyncing
 
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .then(
+                    if (offline) {
+                        Modifier.background(
+                            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.35f),
+                            MaterialTheme.shapes.small,
+                        )
+                    } else {
+                        Modifier
+                    },
+                )
+                .padding(horizontal = if (offline) 8.dp else 0.dp, vertical = if (offline) 6.dp else 0.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -109,17 +178,33 @@ fun OfflineSyncStatusRow(
                     Icon(
                         Icons.Default.CloudOff,
                         contentDescription = statusText,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(22.dp),
                     )
             }
             Column {
                 Text(
                     text = statusText,
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style =
+                        if (offline) {
+                            MaterialTheme.typography.titleSmall
+                        } else {
+                            MaterialTheme.typography.labelLarge
+                        },
+                    color =
+                        if (offline) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
                 )
-                if (lastSyncText != null) {
+                if (offline) {
+                    Text(
+                        text = stringResource(R.string.connectivity_status_offline_hint),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else if (lastSyncText != null) {
                     Text(
                         text = stringResource(R.string.last_sync_attempt_at, lastSyncText),
                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/jotty/android/ui/common/ListScreenComponents.kt
+++ b/app/src/main/java/com/jotty/android/ui/common/ListScreenComponents.kt
@@ -15,12 +15,12 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import kotlinx.coroutines.launch
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.jotty.android.R
+import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
 

--- a/app/src/main/java/com/jotty/android/ui/common/ListScreenComponents.kt
+++ b/app/src/main/java/com/jotty/android/ui/common/ListScreenComponents.kt
@@ -262,7 +262,7 @@ fun ListScreenContent(
     val pullRefreshState = rememberPullToRefreshState()
     when {
         loading && isEmpty -> LoadingState()
-        error != null -> ErrorState(message = error, onRetry = onRetry)
+        error != null && isEmpty -> ErrorState(message = error, onRetry = onRetry)
         isEmpty ->
             EmptyState(
                 icon = emptyIcon,

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
@@ -26,6 +26,7 @@ import com.jotty.android.data.api.API_CATEGORY_UNCATEGORIZED
 import com.jotty.android.data.api.JottyApi
 import com.jotty.android.data.api.Note
 import com.jotty.android.data.encryption.BiometricPassphraseStore
+import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.local.OfflineNotesRepository
 import com.jotty.android.data.preferences.SettingsRepository
 import com.jotty.android.ui.common.ListScreenContent
@@ -65,7 +66,7 @@ fun OfflineEnabledNotesScreen(
     // Observe notes from local database
     val notes by offlineRepository.getNotesFlow().collectAsStateWithLifecycle(initialValue = emptyList())
     val conflictCopies by offlineRepository.getConflictCopiesFlow().collectAsStateWithLifecycle(initialValue = emptyList())
-    val isOnline by offlineRepository.isOnline.collectAsStateWithLifecycle()
+    val isOnline by NetworkConnectivityMonitor.isOnline.collectAsStateWithLifecycle()
     val isSyncing by offlineRepository.isSyncing.collectAsStateWithLifecycle()
     val conflictsDetected by offlineRepository.conflictsDetected.collectAsStateWithLifecycle()
     val lastSyncAttemptEpochMs by offlineRepository.lastSyncAttemptEpochMs.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
@@ -30,6 +30,7 @@ import com.jotty.android.data.local.OfflineNotesRepository
 import com.jotty.android.data.preferences.SettingsRepository
 import com.jotty.android.ui.common.ListScreenContent
 import com.jotty.android.ui.common.MainNestedScaffoldContentWindowInsets
+import com.jotty.android.ui.common.OfflineConnectivityBanner
 import com.jotty.android.ui.common.OfflineSyncStatusRow
 import com.jotty.android.ui.common.SwipeToDeleteContainer
 import com.jotty.android.ui.common.mainScreenTabContentPadding
@@ -162,7 +163,11 @@ fun OfflineEnabledNotesScreen(
         ) {
             when (val note = selectedNote) {
                 null -> {
-                    // Header with sync status and actions; the app bar owns the screen title.
+                    OfflineConnectivityBanner(
+                        isOnline = isOnline,
+                        onRetrySync = { requestSync(showLoading = true) },
+                        modifier = Modifier.padding(bottom = 8.dp),
+                    )
                     OfflineSyncStatusRow(
                         isOnline = isOnline,
                         isSyncing = isSyncing,
@@ -375,6 +380,7 @@ fun OfflineEnabledNotesScreen(
                         debugLoggingEnabled = debugLoggingEnabled,
                         imageLoader = imageLoader,
                         isOnline = isOnline,
+                        onRetrySync = { requestSync(showLoading = true) },
                         biometricStore = biometricStore,
                     )
                 }

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineEnabledNotesScreen.kt
@@ -101,11 +101,16 @@ fun OfflineEnabledNotesScreen(
             screenState.errorMessage = null
             val result = offlineRepository.syncNotes()
             if (result.isFailure) {
-                screenState.errorMessage =
+                val msg =
                     ApiErrorHelper.userMessage(
                         context,
                         result.exceptionOrNull() ?: Exception("Sync failed"),
                     )
+                if (notes.isEmpty()) {
+                    screenState.errorMessage = msg
+                } else {
+                    snackbarHostState.showSnackbar(msg)
+                }
             }
             if (showLoading) screenState.loading = false
         }

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNoteDetailScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNoteDetailScreen.kt
@@ -7,12 +7,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
-import com.jotty.android.ui.common.OfflineConnectivityBanner
 import com.jotty.android.data.api.JottyApi
 import com.jotty.android.data.api.Note
 import com.jotty.android.data.api.UpdateNoteRequest
 import com.jotty.android.data.encryption.BiometricPassphraseStore
 import com.jotty.android.data.local.OfflineNotesRepository
+import com.jotty.android.ui.common.OfflineConnectivityBanner
 import com.jotty.android.util.AppLog
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNoteDetailScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNoteDetailScreen.kt
@@ -1,7 +1,13 @@
 package com.jotty.android.ui.notes
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import coil.ImageLoader
+import com.jotty.android.ui.common.OfflineConnectivityBanner
 import com.jotty.android.data.api.JottyApi
 import com.jotty.android.data.api.Note
 import com.jotty.android.data.api.UpdateNoteRequest
@@ -27,6 +33,7 @@ fun OfflineNoteDetailScreen(
     debugLoggingEnabled: Boolean = false,
     imageLoader: ImageLoader? = null,
     isOnline: Boolean = false,
+    onRetrySync: () -> Unit = {},
     biometricStore: BiometricPassphraseStore? = null,
 ) {
     val scope = rememberCoroutineScope()
@@ -150,21 +157,27 @@ fun OfflineNoteDetailScreen(
             }
         }
 
-    // Use the original NoteDetailScreen with our wrapped API
-    NoteDetailScreen(
-        note = note,
-        api = offlineApi,
-        onBack = onBack,
-        onUpdate = onUpdate,
-        onDelete = {
-            scope.launch {
-                offlineRepository.deleteNote(note.id)
-                onDelete()
-            }
-        },
-        onSaveFailed = onSaveFailed,
-        debugLoggingEnabled = debugLoggingEnabled,
-        imageLoader = imageLoader,
-        biometricStore = biometricStore,
-    )
+    Column(Modifier.fillMaxSize()) {
+        OfflineConnectivityBanner(
+            isOnline = isOnline,
+            onRetrySync = onRetrySync,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+        NoteDetailScreen(
+            note = note,
+            api = offlineApi,
+            onBack = onBack,
+            onUpdate = onUpdate,
+            onDelete = {
+                scope.launch {
+                    offlineRepository.deleteNote(note.id)
+                    onDelete()
+                }
+            },
+            onSaveFailed = onSaveFailed,
+            debugLoggingEnabled = debugLoggingEnabled,
+            imageLoader = imageLoader,
+            biometricStore = biometricStore,
+        )
+    }
 }

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
@@ -39,9 +39,10 @@ fun OfflineNotesScreen(
         )
     val offlineRepository = vm.repository
     val offlineModeEnabled by settingsRepository.offlineModeEnabled.collectAsStateWithLifecycle(initialValue = true)
+    val isOnline by offlineRepository.isOnline.collectAsStateWithLifecycle()
 
-    LaunchedEffect(offlineModeEnabled, instanceId) {
-        if (offlineModeEnabled) {
+    LaunchedEffect(offlineModeEnabled, instanceId, authFingerprint, isOnline) {
+        if (offlineModeEnabled && isOnline) {
             offlineRepository.syncNotes()
         }
     }

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.ImageLoader
 import com.jotty.android.data.api.JottyApi
-import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.encryption.BiometricPassphraseStore
+import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.preferences.SettingsRepository
 
 /**

--- a/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/OfflineNotesScreen.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.ImageLoader
 import com.jotty.android.data.api.JottyApi
+import com.jotty.android.data.local.NetworkConnectivityMonitor
 import com.jotty.android.data.encryption.BiometricPassphraseStore
 import com.jotty.android.data.preferences.SettingsRepository
 
@@ -39,7 +40,7 @@ fun OfflineNotesScreen(
         )
     val offlineRepository = vm.repository
     val offlineModeEnabled by settingsRepository.offlineModeEnabled.collectAsStateWithLifecycle(initialValue = true)
-    val isOnline by offlineRepository.isOnline.collectAsStateWithLifecycle()
+    val isOnline by NetworkConnectivityMonitor.isOnline.collectAsStateWithLifecycle()
 
     LaunchedEffect(offlineModeEnabled, instanceId, authFingerprint, isOnline) {
         if (offlineModeEnabled && isOnline) {

--- a/app/src/main/java/com/jotty/android/util/ApiErrorHelper.kt
+++ b/app/src/main/java/com/jotty/android/util/ApiErrorHelper.kt
@@ -22,15 +22,35 @@ object ApiErrorHelper {
     ): String {
         if (t is HttpException) {
             httpExceptionDetail(t)?.let { return it }
+            return context.getString(errorMessageResId(t))
         }
+        val cause = t.cause
+        if (cause is HttpException) {
+            return userMessage(context, cause)
+        }
+        preformattedUserMessage(t.message)?.let { return it }
         return context.getString(errorMessageResId(t))
     }
 
-    /** Best-effort parse of JSON error body (e.g. `{ "message": "..." }`). */
+    /** Repository/sync code may attach a short message; ignore Retrofit status lines and HTML. */
+    private fun preformattedUserMessage(message: String?): String? {
+        val trimmed = message?.trim().orEmpty()
+        if (trimmed.isEmpty()) return null
+        if (trimmed.startsWith("HTTP ", ignoreCase = true)) return null
+        if (isHtmlErrorBody(trimmed)) return null
+        return trimmed.take(SERVER_MESSAGE_MAX_LEN)
+    }
+
+    /** Best-effort parse of JSON or plain-text API error body; ignores HTML/proxy pages. */
     private fun httpExceptionDetail(t: HttpException): String? {
         return try {
-            val raw = t.response()?.errorBody()?.use { it.string() }?.trim().orEmpty()
+            val response = t.response() ?: return null
+            val contentType = response.headers()["Content-Type"]?.lowercase().orEmpty()
+            if (contentType.contains("text/html")) return null
+
+            val raw = response.errorBody()?.use { it.string() }?.trim().orEmpty()
             if (raw.isEmpty()) return null
+            if (isHtmlErrorBody(raw)) return null
             if (!raw.startsWith("{")) {
                 return raw.take(SERVER_MESSAGE_MAX_LEN)
             }
@@ -44,6 +64,15 @@ object ApiErrorHelper {
         } catch (_: Exception) {
             null
         }
+    }
+
+    /** Visible for testing: nginx/reverse-proxy HTML must not be shown in the UI. */
+    internal fun isHtmlErrorBody(body: String): Boolean {
+        val trimmed = body.trimStart()
+        val lower = trimmed.lowercase()
+        return lower.startsWith("<!doctype") ||
+            lower.startsWith("<html") ||
+            (lower.contains("<html") && lower.contains("</html>"))
     }
 
     /** Visible for testing: returns the string resource ID for the given throwable. */

--- a/app/src/main/java/com/jotty/android/util/ApkInstallHelper.kt
+++ b/app/src/main/java/com/jotty/android/util/ApkInstallHelper.kt
@@ -89,6 +89,7 @@ object ApkInstallHelper {
     ): Long? {
         return try {
             val pm = context.packageManager
+
             @Suppress("DEPRECATION")
             val flags =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -151,6 +152,7 @@ object ApkInstallHelper {
     ): Set<String>? {
         return try {
             val pm = context.packageManager
+
             @Suppress("DEPRECATION")
             val flags =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/app/src/main/java/com/jotty/android/util/ApkInstallHelper.kt
+++ b/app/src/main/java/com/jotty/android/util/ApkInstallHelper.kt
@@ -1,0 +1,194 @@
+package com.jotty.android.util
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Validates and launches APK installs from app cache (in-app updates).
+ */
+object ApkInstallHelper {
+    /**
+     * Dev CI uses a monotonic [versionCode] per workflow run so in-app dev updates are not blocked
+     * when [gradle.properties] [VERSION_CODE] is unchanged between pushes.
+     */
+    fun devCiVersionCode(
+        baseVersionCode: Int,
+        ciRunNumber: Int,
+    ): Int = baseVersionCode * 10_000 + (ciRunNumber % 10_000)
+
+    /**
+     * Returns false when the downloaded APK is signed with a different key than the installed app.
+     * Returns true when signatures match or either side cannot be read (installer will decide).
+     */
+    fun canInstallOverExisting(
+        context: Context,
+        apkFile: File,
+    ): Boolean {
+        val installed = signingCertificateDigests(context, context.packageName) ?: return true
+        val incoming = signingCertificateDigestsFromApk(context, apkFile) ?: return true
+        if (installed.isEmpty() || incoming.isEmpty()) return true
+        return installed.intersect(incoming).isNotEmpty()
+    }
+
+    /**
+     * Returns false when the APK [versionCode] is lower than the installed app (Android blocks downgrades).
+     */
+    fun isVersionCodeAllowedForUpdate(
+        context: Context,
+        apkFile: File,
+    ): Boolean {
+        val installedCode = installedVersionCode(context) ?: return true
+        val apkCode = apkVersionCode(context, apkFile) ?: return true
+        return apkCode >= installedCode
+    }
+
+    fun grantReadPermissionToInstallers(
+        context: Context,
+        uri: android.net.Uri,
+        installIntent: Intent,
+    ) {
+        val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        val resolvers =
+            context.packageManager.queryIntentActivities(
+                installIntent,
+                PackageManager.MATCH_DEFAULT_ONLY,
+            )
+        for (resolve in resolvers) {
+            val pkg = resolve.activityInfo.packageName
+            context.grantUriPermission(pkg, uri, flags)
+        }
+    }
+
+    private fun installedVersionCode(context: Context): Long? {
+        return try {
+            val pm = context.packageManager
+            val info =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    pm.getPackageInfo(
+                        context.packageName,
+                        PackageManager.PackageInfoFlags.of(0),
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    pm.getPackageInfo(context.packageName, 0)
+                }
+            packageVersionCode(info)
+        } catch (e: Exception) {
+            AppLog.e(TAG, "Installed versionCode read failed", e)
+            null
+        }
+    }
+
+    private fun apkVersionCode(
+        context: Context,
+        apkFile: File,
+    ): Long? {
+        return try {
+            val pm = context.packageManager
+            @Suppress("DEPRECATION")
+            val flags =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    PackageManager.GET_SIGNING_CERTIFICATES
+                } else {
+                    PackageManager.GET_SIGNATURES
+                }
+            val info = pm.getPackageArchiveInfo(apkFile.absolutePath, flags) ?: return null
+            info.applicationInfo?.let { appInfo ->
+                appInfo.sourceDir = apkFile.absolutePath
+                appInfo.publicSourceDir = apkFile.absolutePath
+            }
+            packageVersionCode(info)
+        } catch (e: Exception) {
+            AppLog.e(TAG, "APK versionCode read failed", e)
+            null
+        }
+    }
+
+    private fun packageVersionCode(info: android.content.pm.PackageInfo): Long {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }
+
+    private fun signingCertificateDigests(
+        context: Context,
+        packageName: String,
+    ): Set<String>? {
+        return try {
+            val pm = context.packageManager
+            val info =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    pm.getPackageInfo(
+                        packageName,
+                        PackageManager.PackageInfoFlags.of(
+                            PackageManager.GET_SIGNING_CERTIFICATES.toLong(),
+                        ),
+                    )
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    @Suppress("DEPRECATION")
+                    pm.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+                } else {
+                    @Suppress("DEPRECATION")
+                    pm.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+                }
+            digestsFromPackageInfo(info)
+        } catch (e: Exception) {
+            AppLog.e(TAG, "Installed signing read failed", e)
+            null
+        }
+    }
+
+    private fun signingCertificateDigestsFromApk(
+        context: Context,
+        apkFile: File,
+    ): Set<String>? {
+        return try {
+            val pm = context.packageManager
+            @Suppress("DEPRECATION")
+            val flags =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    PackageManager.GET_SIGNING_CERTIFICATES
+                } else {
+                    PackageManager.GET_SIGNATURES
+                }
+            val info = pm.getPackageArchiveInfo(apkFile.absolutePath, flags) ?: return null
+            info.applicationInfo?.let { appInfo ->
+                appInfo.sourceDir = apkFile.absolutePath
+                appInfo.publicSourceDir = apkFile.absolutePath
+            }
+            digestsFromPackageInfo(info)
+        } catch (e: Exception) {
+            AppLog.e(TAG, "APK signing read failed", e)
+            null
+        }
+    }
+
+    private fun digestsFromPackageInfo(info: android.content.pm.PackageInfo): Set<String> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signingInfo = info.signingInfo ?: return emptySet()
+            val signatures =
+                if (signingInfo.hasMultipleSigners()) {
+                    signingInfo.apkContentsSigners
+                } else {
+                    signingInfo.signingCertificateHistory
+                }
+            return signatures?.map { sha256Hex(it.toByteArray()) }?.toSet() ?: emptySet()
+        }
+        @Suppress("DEPRECATION")
+        return info.signatures?.map { sha256Hex(it.toByteArray()) }?.toSet() ?: emptySet()
+    }
+
+    private fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    private const val TAG = "ApkInstallHelper"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,10 @@
     <string name="sync_failed">Sync failed</string>
     <string name="offline">Offline</string>
     <string name="online">Online</string>
+    <string name="connectivity_not_established_title">No connection to Jotty</string>
+    <string name="connectivity_not_established_body">The app cannot reach your server right now. Changes you make are saved on this device and will sync when connectivity is restored.</string>
+    <string name="connectivity_retry_sync">Try sync</string>
+    <string name="connectivity_status_offline_hint">Server unreachable — pull to refresh after you are back online</string>
     <string name="saved_locally">Saved locally</string>
     <string name="undo">Undo</string>
     <string name="will_sync_when_online">Will sync when online</string>
@@ -227,7 +231,9 @@
     <string name="update_version_dev_format">Dev %1$s</string>
     <string name="downloading">Downloading…</string>
     <string name="install_failed">%1$s. You can install from the release page.</string>
-    <string name="update_signing_mismatch_hint">If the installer says “App not installed”, the APK may be signed differently than your installed app (common when switching between stable and dev). Uninstall Jotty once, then install the new APK. Your Jotty server data is not affected.</string>
+    <string name="update_signing_mismatch_hint">If the installer says “App not installed”, the APK may be signed differently than your installed app (e.g. Android Studio debug vs GitHub release). Uninstall Jotty once, then install from the release page. Your Jotty server data is not affected.</string>
+    <string name="update_signing_mismatch_blocked">This update is signed with a different key than your installed app. Uninstall Jotty once, then install from the release page.</string>
+    <string name="update_version_downgrade_blocked">This build has an older version code than your installed app. Uninstall once, then install from the release page.</string>
     <string name="update_dev_channel_hint">Dev builds update from the dev-latest release. Use the same signing as stable for in-app updates; otherwise uninstall once before installing dev.</string>
     <string name="open_release_page">Open release page</string>
     <string name="whats_new">What\'s new</string>

--- a/app/src/test/java/com/jotty/android/data/local/NetworkConnectivityMonitorTest.kt
+++ b/app/src/test/java/com/jotty/android/data/local/NetworkConnectivityMonitorTest.kt
@@ -1,0 +1,21 @@
+package com.jotty.android.data.local
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkConnectivityMonitorTest {
+    @After
+    fun tearDown() {
+        NetworkConnectivityMonitor.resetForTests()
+    }
+
+    @Test
+    fun setOnlineForTests_updatesFlow() {
+        NetworkConnectivityMonitor.setOnlineForTests(true)
+        assertTrue(NetworkConnectivityMonitor.isOnline.value)
+        NetworkConnectivityMonitor.setOnlineForTests(false)
+        assertFalse(NetworkConnectivityMonitor.isOnline.value)
+    }
+}

--- a/app/src/test/java/com/jotty/android/data/local/OfflineChecklistsRepositoryTest.kt
+++ b/app/src/test/java/com/jotty/android/data/local/OfflineChecklistsRepositoryTest.kt
@@ -65,7 +65,7 @@ class OfflineChecklistsRepositoryTest {
                     instanceId = instanceId,
                     api = FakeChecklistApi(),
                     initialOnlineOverride = false,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val result = repo.syncChecklists(force = true)
@@ -100,7 +100,7 @@ class OfflineChecklistsRepositoryTest {
                     instanceId = instanceId,
                     api = FakeChecklistApi(),
                     initialOnlineOverride = false,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val result = repo.updateChecklist("list-1", "New title")
@@ -156,7 +156,7 @@ class OfflineChecklistsRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val result = repo.syncChecklists(force = true)
@@ -209,7 +209,7 @@ class OfflineChecklistsRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             assertTrue(repo.syncChecklists(force = true).isFailure)

--- a/app/src/test/java/com/jotty/android/data/local/OfflineNotesRepositoryTest.kt
+++ b/app/src/test/java/com/jotty/android/data/local/OfflineNotesRepositoryTest.kt
@@ -52,7 +52,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = false,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
             val result = repo.syncNotes()
             assertTrue(result.isFailure)
@@ -74,7 +74,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
             assertTrue(repo.syncNotes().isSuccess)
             val stored = database.noteDao().getAllNotes(instanceId)
@@ -132,7 +132,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
             assertTrue(repo.syncNotes().isSuccess)
             val stored = database.noteDao().getAllNotes(instanceId)
@@ -151,7 +151,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = FakeJottyApi(),
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
             database.noteDao().insertNotes(
                 listOf(
@@ -211,7 +211,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val result = repo.createNote(title = "Offline note", content = "body")
@@ -269,7 +269,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val result = repo.updateNote("existing-server-id", "New Title", "new body", API_CATEGORY_UNCATEGORIZED)
@@ -311,7 +311,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = false,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val createResult = repo.createNote(title = "Draft", content = "v1")
@@ -333,7 +333,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
             val syncResult = onlineRepo.syncNotes()
             assertTrue(syncResult.isSuccess)
@@ -359,7 +359,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             val createResult = repo.createNote(title = "Local only", content = "")
@@ -375,7 +375,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = false,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
             val deleteResult = offlineRepo.deleteNote(localId)
 
@@ -425,7 +425,7 @@ class OfflineNotesRepositoryTest {
                     instanceId = instanceId,
                     api = api,
                     initialOnlineOverride = true,
-                    registerNetworkCallback = false,
+                    useSharedConnectivity = false,
                 )
 
             assertTrue(repo.syncNotes().isFailure)

--- a/app/src/test/java/com/jotty/android/data/updates/UpdateCheckerTest.kt
+++ b/app/src/test/java/com/jotty/android/data/updates/UpdateCheckerTest.kt
@@ -1,6 +1,7 @@
 package com.jotty.android.data.updates
 
 import com.jotty.android.data.updates.GitHubAsset
+import com.jotty.android.util.ApkInstallHelper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -131,5 +132,12 @@ class UpdateCheckerTest {
     fun `preferredApkAsset falls back to debug when only debug attached`() {
         val assets = listOf(GitHubAsset("jotty-android-debug.apk", "https://example.com/debug"))
         assertEquals("jotty-android-debug.apk", UpdateChecker.preferredApkAsset(assets)?.name)
+    }
+
+    @Test
+    fun `devCiVersionCode increments within base version band`() {
+        assertEquals(270001, ApkInstallHelper.devCiVersionCode(27, 1))
+        assertEquals(279999, ApkInstallHelper.devCiVersionCode(27, 9999))
+        assertEquals(280042, ApkInstallHelper.devCiVersionCode(28, 42))
     }
 }

--- a/app/src/test/java/com/jotty/android/data/updates/UpdateCheckerTest.kt
+++ b/app/src/test/java/com/jotty/android/data/updates/UpdateCheckerTest.kt
@@ -1,6 +1,5 @@
 package com.jotty.android.data.updates
 
-import com.jotty.android.data.updates.GitHubAsset
 import com.jotty.android.util.ApkInstallHelper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/app/src/test/java/com/jotty/android/util/ApiErrorHelperTest.kt
+++ b/app/src/test/java/com/jotty/android/util/ApiErrorHelperTest.kt
@@ -132,4 +132,23 @@ class ApiErrorHelperTest {
             ApiErrorHelper.errorMessageResId(RuntimeException()),
         )
     }
+
+    @Test
+    fun isHtmlErrorBody_detects_nginx_forbidden_page() {
+        val nginx403 =
+            """
+            <html>
+            <head><title>403 Forbidden</title></head>
+            <body>
+            <center><h1>403 Forbidden</h1></center>
+            </body>
+            </html>
+            """.trimIndent()
+        assertEquals(true, ApiErrorHelper.isHtmlErrorBody(nginx403))
+    }
+
+    @Test
+    fun isHtmlErrorBody_allows_plain_api_message() {
+        assertEquals(false, ApiErrorHelper.isHtmlErrorBody("Invalid API key"))
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # App version (single source of truth — bump when cutting a release)
-VERSION_NAME=1.3.4
-VERSION_CODE=27
+VERSION_NAME=1.3.5
+VERSION_CODE=28
 android.defaults.buildfeatures.resvalues=true
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.enableAppCompileTimeRClass=false

--- a/scripts/pull-dev.ps1
+++ b/scripts/pull-dev.ps1
@@ -1,0 +1,13 @@
+# Pull dev branch and tags (dev-latest tag updates safely after setup-repo-git).
+param(
+    [switch]$NoSetup
+)
+
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+
+if (-not $NoSetup) {
+    & (Join-Path $PSScriptRoot "setup-repo-git.ps1")
+}
+
+git pull --tags origin dev

--- a/scripts/pull-dev.sh
+++ b/scripts/pull-dev.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Pull dev branch and tags (dev-latest tag updates safely after setup-repo-git).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+no_setup=false
+if [[ "${1:-}" == "--no-setup" ]]; then
+  no_setup=true
+fi
+
+if [[ "$no_setup" != "true" ]]; then
+  "$(dirname "$0")/setup-repo-git.sh"
+fi
+
+git pull --tags origin dev

--- a/scripts/setup-repo-git.ps1
+++ b/scripts/setup-repo-git.ps1
@@ -1,0 +1,23 @@
+# One-time (per clone) Git config so the moving dev-latest tag updates on fetch/pull without
+# "would clobber existing tag". Safe to run again (idempotent).
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+
+$refspec = "+refs/tags/dev-latest:refs/tags/dev-latest"
+$existing = @(git config --get-all remote.origin.fetch 2>$null)
+if ($existing -contains $refspec) {
+    Write-Host "Already configured: force-fetch dev-latest on origin fetch."
+} else {
+    git config --add remote.origin.fetch $refspec
+    Write-Host "Added remote.origin.fetch entry for dev-latest (force-update tag)."
+}
+
+$hooksDir = ".githooks"
+if (Test-Path $hooksDir) {
+    git config core.hooksPath $hooksDir
+    Write-Host "Set core.hooksPath to $hooksDir (post-merge syncs dev-latest on dev)."
+}
+
+git fetch origin tag dev-latest --force
+Write-Host "Local dev-latest tag matches origin."
+Write-Host "You can use: git pull --tags origin dev  (or .\scripts\pull-dev.ps1)"

--- a/scripts/setup-repo-git.sh
+++ b/scripts/setup-repo-git.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# One-time (per clone) Git config so the moving dev-latest tag updates on fetch/pull without
+# "would clobber existing tag". Safe to run again (idempotent).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+refspec='+refs/tags/dev-latest:refs/tags/dev-latest'
+if git config --get-all remote.origin.fetch | grep -Fxq "$refspec"; then
+  echo "Already configured: force-fetch dev-latest on origin fetch."
+else
+  git config --add remote.origin.fetch "$refspec"
+  echo "Added remote.origin.fetch entry for dev-latest (force-update tag)."
+fi
+
+if [[ -d .githooks ]]; then
+  git config core.hooksPath .githooks
+  echo "Set core.hooksPath to .githooks (post-merge syncs dev-latest on dev)."
+fi
+
+git fetch origin tag dev-latest --force
+echo "Local dev-latest tag matches origin."
+echo "You can use: git pull --tags origin dev  (or ./scripts/pull-dev.sh)"

--- a/scripts/sync-dev-latest-tag.ps1
+++ b/scripts/sync-dev-latest-tag.ps1
@@ -1,6 +1,5 @@
-# Updates the local dev-latest tag from origin (safe when pull --tags fails with "would clobber").
-# dev-latest is a moving tag recreated by CI on every push to dev.
+# Updates the local dev-latest tag from origin.
+# Prefer setup-repo-git.ps1 once per clone so "git pull --tags" never clobbers dev-latest.
 $ErrorActionPreference = "Stop"
 Set-Location (Join-Path $PSScriptRoot "..")
-git fetch origin tag dev-latest --force
-Write-Host "Local tag dev-latest now matches origin."
+& (Join-Path $PSScriptRoot "setup-repo-git.ps1")

--- a/scripts/sync-dev-latest-tag.sh
+++ b/scripts/sync-dev-latest-tag.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Updates the local dev-latest tag from origin (safe when pull --tags fails with "would clobber").
+# Updates the local dev-latest tag from origin.
+# Prefer setup-repo-git.sh once per clone so "git pull --tags" never clobbers dev-latest.
 set -euo pipefail
-cd "$(dirname "$0")/.."
-git fetch origin tag dev-latest --force
-echo "Local tag dev-latest now matches origin."
+"$(dirname "$0")/setup-repo-git.sh"

--- a/scripts/sync-dev-with-main.ps1
+++ b/scripts/sync-dev-with-main.ps1
@@ -1,0 +1,17 @@
+# Fast-forward origin/dev to origin/main (same as post-release CI sync).
+# Use when main is "ahead" only due to merge commits from release PRs.
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+git fetch origin main dev
+$main = git rev-parse origin/main
+$dev = git rev-parse origin/dev
+if ($main -eq $dev) {
+    Write-Host "dev already matches main ($($main.Substring(0,7)))."
+    exit 0
+}
+git merge-base --is-ancestor origin/dev origin/main 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw "dev is not an ancestor of main — merge main into dev manually before syncing."
+}
+git push origin "origin/main:refs/heads/dev"
+Write-Host "dev fast-forwarded to main ($($main.Substring(0,7)))."

--- a/scripts/sync-dev-with-main.sh
+++ b/scripts/sync-dev-with-main.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fast-forward origin/dev to origin/main (same as post-release CI sync).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+git fetch origin main dev
+if [ "$(git rev-parse origin/dev)" = "$(git rev-parse origin/main)" ]; then
+  echo "dev already matches main."
+  exit 0
+fi
+if ! git merge-base --is-ancestor origin/dev origin/main; then
+  echo "dev is not an ancestor of main — merge main into dev manually." >&2
+  exit 1
+fi
+git push origin origin/main:refs/heads/dev
+echo "dev fast-forwarded to $(git rev-parse --short origin/main)."


### PR DESCRIPTION
### Fixed

- **Git `dev-latest` tag on pull** — `scripts/setup-repo-git` adds a force-fetch refspec so `git pull --tags` no longer fails with “would clobber existing tag”; `scripts/pull-dev` runs setup and pulls `dev`. Optional `.githooks/post-merge` keeps the tag in sync on `dev` when `core.hooksPath` is set via setup.
- **Dev in-app updates (“App not installed”)** — `dev-latest` CI assigns a monotonic `versionCode` per workflow run (same signing as stable when secrets are set). The app checks APK signing and version code before opening the installer and shows a clear message when the installed build was debug-signed or sideloaded with a different key.
- **Offline checklists stuck offline ([#27](https://github.com/Darknetzz/jotty-android/issues/27))** — Notes and checklists share one app-wide `NetworkConnectivityMonitor` (single network callback) so tab switches no longer desync Online/Offline; offline UI reads the shared online state. Sync runs when connectivity is restored. Homelab/LAN: online when `INTERNET` is available (not only `VALIDATED`); connectivity is re-checked when the app returns to foreground.
- **Offline sync error display** — Reverse-proxy HTML (e.g. nginx `403 Forbidden`) is no longer shown in the UI; users see “Access denied” instead. Sync failures keep local offline items visible (snackbar + last-error row) instead of a full-screen error that hides them.

### Changed

- **Offline connectivity UX** — Prominent error banner and highlighted offline status when the server cannot be reached; **Try sync** on list and detail screens.
- **Branch sync after release** — CI fast-forwards `dev` to `main` after each push to `main`, so release merge commits do not leave `main` ahead of `dev` with identical trees.

**Full changelog:** https://github.com/Darknetzz/jotty-android/blob/main/CHANGELOG.md#135---2026-05-24
