### PR TITLE
chore(deps): low-risk library bumps (batch 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 ### Changed
 
 - **Dependencies** — Updated AndroidX (Compose BOM, Lifecycle, Room, DataStore, Work, Security Crypto), Retrofit 3, and CI actions; no intended behavior change.
+- **Dependencies** — Bumped Navigation Compose, Fragment KTX, KSP, and Android test JUnit; no intended behavior change.
 - **Settings → Appearance** — Theme, colors, padding, reader text size, and reduced motion now live on a dedicated Appearance screen opened from Settings.
 - **Settings → Dashboard overview** — Summary stats and admin totals open on a dedicated screen with pull-to-refresh, instead of inline on Settings.
 - **Settings → Behavior** — Start screen, swipe-to-delete, note previews, and offline sync now live on a dedicated Behavior screen opened from Settings.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,7 +114,7 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.11.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")
-    implementation("androidx.navigation:navigation-compose:2.9.7")
+    implementation("androidx.navigation:navigation-compose:2.9.8")
 
     // Retrofit for REST API
     implementation("com.squareup.retrofit2:retrofit:3.0.0")
@@ -148,7 +148,7 @@ dependencies {
     // Biometric authentication (note passphrase protection)
     implementation("androidx.biometric:biometric:1.1.0")
     // FragmentActivity is required by BiometricPrompt; declared explicitly to avoid relying on transitive resolution.
-    implementation("androidx.fragment:fragment-ktx:1.8.5")
+    implementation("androidx.fragment:fragment-ktx:1.8.9")
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")
@@ -162,6 +162,6 @@ dependencies {
 
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test:runner:1.6.2")
 }

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -15,6 +15,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 ### Changed
 
 - **Dependencies** — Updated AndroidX (Compose BOM, Lifecycle, Room, DataStore, Work, Security Crypto), Retrofit 3, and CI actions; no intended behavior change.
+- **Dependencies** — Bumped Navigation Compose, Fragment KTX, KSP, and Android test JUnit; no intended behavior change.
 - **Settings → Appearance** — Theme, colors, padding, reader text size, and reduced motion now live on a dedicated Appearance screen opened from Settings.
 - **Settings → Dashboard overview** — Summary stats and admin totals open on a dedicated screen with pull-to-refresh, instead of inline on Settings.
 - **Settings → Behavior** — Start screen, swipe-to-delete, note previews, and offline sync now live on a dedicated Behavior screen opened from Settings.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.1"
 kotlin = "2.2.21"
-ksp = "2.3.6"
+ksp = "2.3.9"
 compose-bom = "2026.05.01"
 ktlint = "12.1.1"
 


### PR DESCRIPTION
## Summary
- Consolidates Dependabot PRs #37, #38, #41, #42 into one validated update.
- Navigation Compose 2.9.8, Fragment KTX 1.8.9, KSP 2.3.9, androidTest ext-junit 1.3.0.

## Test plan
- [x] \./gradlew test lintDebug lintRelease ktlintCheck assembleDebug\

Closes superseded Dependabot bumps when merged.

Made with [Cursor](https://cursor.com)