### PR TITLE
Fix encrypted note save corrupting ciphertext (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Fixed
 
+- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
 
 ---

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -8,6 +8,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Fixed
 
+- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt now requires decrypted body text; frontmatter titles with `---` or colons are YAML-quoted so the encrypted JSON body is not truncated on parse.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
 
 ---

--- a/app/src/main/java/com/jotty/android/data/encryption/NoteEncryption.kt
+++ b/app/src/main/java/com/jotty/android/data/encryption/NoteEncryption.kt
@@ -45,7 +45,7 @@ object NoteEncryption {
         // 1) Frontmatter format: --- ... encrypted: true ... --- \n body
         if (trimmed.startsWith(FRONTMATTER_START)) {
             val afterFirst = trimmed.substring(FRONTMATTER_START.length)
-            val endOfFront = afterFirst.indexOf(FRONTMATTER_END)
+            val endOfFront = findFrontmatterEnd(afterFirst)
             if (endOfFront != -1) {
                 val frontmatterStr = afterFirst.substring(0, endOfFront).trim().replace("\r\n", "\n").replace("\r", "\n")
                 val body = afterFirst.substring(endOfFront + FRONTMATTER_END.length).trim()
@@ -81,4 +81,14 @@ object NoteEncryption {
      * Returns true if [content] is an encrypted note (frontmatter or encrypted JSON body).
      */
     fun isEncrypted(content: String): Boolean = parse(content) is ParsedNoteContent.Encrypted
+
+    /**
+     * Closing `---` must be on its own line so titles/values containing `---` do not truncate the body.
+     */
+    private fun findFrontmatterEnd(afterOpeningDelimiter: String): Int {
+        val normalized = afterOpeningDelimiter.replace("\r\n", "\n").replace("\r", "\n")
+        val regex = Regex("""\n---(?:\n|$)""")
+        val match = regex.find(normalized) ?: return -1
+        return match.range.first + 1 // skip leading newline; points at closing ---
+    }
 }

--- a/app/src/main/java/com/jotty/android/data/encryption/XChaCha20Encryptor.kt
+++ b/app/src/main/java/com/jotty/android/data/encryption/XChaCha20Encryptor.kt
@@ -89,6 +89,7 @@ object XChaCha20Encryptor {
 
     /**
      * Builds full note content with YAML frontmatter for Jotty (encrypted: true, encryptionMethod: xchacha).
+     * Title and uuid are quoted when needed so values containing `---` or colons do not break parsing.
      */
     fun wrapWithFrontmatter(
         noteId: String,
@@ -96,15 +97,32 @@ object XChaCha20Encryptor {
         category: String,
         encryptedBodyJson: String,
     ): String {
+        val safeUuid = yamlScalar(noteId)
+        val safeTitle = yamlScalar(noteTitle)
         return """
             |---
-            |uuid: $noteId
-            |title: $noteTitle
+            |uuid: $safeUuid
+            |title: $safeTitle
             |encrypted: true
             |encryptionMethod: xchacha
             |---
             |$encryptedBodyJson
             """.trimMargin()
+    }
+
+    /** YAML scalar for frontmatter; double-quoted when special characters would confuse [NoteEncryption.parse]. */
+    internal fun yamlScalar(value: String): String {
+        if (value.isEmpty()) return "\"\""
+        val needsQuotes =
+            value.any { it == '\n' || it == '\r' || it == ':' || it == '#' } ||
+                value.contains("---") ||
+                value != value.trim() ||
+                value.any { it == '"' || it == '\\' }
+        return if (needsQuotes) {
+            "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        } else {
+            value
+        }
     }
 
     /**

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.jotty.android.ui.notes
 
 import android.content.ClipData
+import android.webkit.WebView
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
@@ -136,6 +137,7 @@ internal fun NoteDetailScreen(
 
     var noteEditMode by rememberSaveable(note.id) { mutableStateOf(NoteEditMode.Markdown) }
     var editorReloadNonce by rememberSaveable(note.id) { mutableIntStateOf(0) }
+    var wysiwygWebView by remember(note.id) { mutableStateOf<WebView?>(null) }
 
     fun currentEditBody(): String = if (isEncrypted) decryptedContent.orEmpty() else content
 
@@ -144,6 +146,17 @@ internal fun NoteDetailScreen(
             detailVm.setDecryptedContent(value)
         } else {
             detailVm.setContent(value)
+        }
+    }
+
+    fun initiateEncryptedSave() {
+        if (noteEditMode == NoteEditMode.Visual) {
+            getWysiwygContent(wysiwygWebView) { html ->
+                setEditBody(html)
+                detailVm.showEncryptDialog()
+            }
+        } else {
+            detailVm.showEncryptDialog()
         }
     }
 
@@ -391,7 +404,7 @@ internal fun NoteDetailScreen(
                             IconButton(
                                 onClick = {
                                     if (isEncrypted) {
-                                        detailVm.showEncryptDialog()
+                                        initiateEncryptedSave()
                                     } else {
                                         detailVm.saveEdit(
                                             onSuccess = onUpdate,
@@ -569,6 +582,7 @@ internal fun NoteDetailScreen(
                                     onCategoryChange = { detailVm.setCategory(it) },
                                     categorySuggestions = categorySuggestions,
                                     showHtmlSaveHint = noteContentContainsRawHtml(editBody),
+                                    onEditorWebView = { wysiwygWebView = it },
                                     modifier = Modifier.fillMaxSize(),
                                 )
                             NoteEditMode.Markdown ->
@@ -653,6 +667,7 @@ internal fun NoteDetailScreen(
 
     if (showEncryptDialog) {
         val encryptFailedMsg = stringResource(R.string.error_encrypt_failed)
+        val encryptNoPlaintextMsg = stringResource(R.string.error_encrypt_no_plaintext)
         val reEncryptMode = isEncrypted && detailVm.hasSessionPassphrase()
         EncryptNoteDialog(
             onDismiss = { detailVm.dismissEncryptDialog() },
@@ -664,6 +679,7 @@ internal fun NoteDetailScreen(
                     encryptFailedMsg,
                     onSuccess = onUpdate,
                     onFailure = onSaveFailed,
+                    encryptNoPlaintextMsg = encryptNoPlaintextMsg,
                 )
             },
             onEncrypt = { passChars ->
@@ -672,6 +688,7 @@ internal fun NoteDetailScreen(
                     encryptFailedMsg,
                     onSuccess = onUpdate,
                     onFailure = onSaveFailed,
+                    encryptNoPlaintextMsg = encryptNoPlaintextMsg,
                 )
             },
         )

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.jotty.android.data.encryption.NoteEncryption
 import com.jotty.android.data.encryption.ParsedNoteContent
 import com.jotty.android.data.encryption.XChaCha20Encryptor
 import com.jotty.android.data.encryption.clearPassphrase
+import com.jotty.android.data.encryption.copyTrimmedOrNull
 import com.jotty.android.util.AppLog
 import com.jotty.android.util.stripInvisibleFromEdges
 import com.jotty.android.util.stripInvisibleUnicode
@@ -156,13 +157,14 @@ class NoteDetailViewModel(
         encryptFailedMsg: String,
         onSuccess: (Note) -> Unit,
         onFailure: () -> Unit,
+        encryptNoPlaintextMsg: String? = null,
     ) {
         val passChars = NotePassphraseSession.get(activeNoteId)
         if (passChars == null) {
             showEncryptDialog()
             return
         }
-        encrypt(passChars, encryptFailedMsg, onSuccess, onFailure)
+        encrypt(passChars, encryptFailedMsg, onSuccess, onFailure, encryptNoPlaintextMsg)
     }
 
     fun setTitle(value: String) {
@@ -227,8 +229,10 @@ class NoteDetailViewModel(
         _legacyEncryptionDetected.value = usedLegacyDataOrder
         sessionSourceFingerprint = contentFingerprint(_content.value)
         NoteDecryptionSession.put(activeNoteId, cleaned)
-        passphrase?.let { NotePassphraseSession.put(activeNoteId, it) }
-        passphrase?.clearPassphrase()
+        passphrase?.copyTrimmedOrNull()?.let { trimmed ->
+            NotePassphraseSession.put(activeNoteId, trimmed)
+            passphrase.clearPassphrase()
+        } ?: passphrase?.clearPassphrase()
         dismissDecryptDialog()
     }
 
@@ -272,14 +276,28 @@ class NoteDetailViewModel(
         encryptFailedMsg: String,
         onSuccess: (Note) -> Unit,
         onFailure: () -> Unit,
+        encryptNoPlaintextMsg: String? = null,
     ) {
         viewModelScope.launch {
             _encryptError.value = null
             _isEncrypting.value = true
-            val plainToEncrypt =
-                stripInvisibleUnicode(
-                    stripInvisibleFromEdges(displayContent ?: _content.value),
+            val plainToEncrypt = resolvePlaintextForEncrypt()
+            if (plainToEncrypt == null) {
+                _encryptError.value = encryptNoPlaintextMsg ?: encryptFailedMsg
+                passChars.clearPassphrase()
+                _isEncrypting.value = false
+                return@launch
+            }
+            if (isEncrypted && NoteEncryption.isEncrypted(plainToEncrypt)) {
+                AppLog.e(
+                    "encryption",
+                    "Refusing to re-encrypt ciphertext as plaintext for note $activeNoteId",
                 )
+                _encryptError.value = encryptNoPlaintextMsg ?: encryptFailedMsg
+                passChars.clearPassphrase()
+                _isEncrypting.value = false
+                return@launch
+            }
             try {
                 val body =
                     withContext(Dispatchers.Default) {
@@ -368,6 +386,19 @@ class NoteDetailViewModel(
 
     internal fun contentFingerprint(content: String): String =
         stripInvisibleFromEdges(content).hashCode().toString()
+
+    /**
+     * Plaintext to encrypt. Re-encrypting an already encrypted note must use session plaintext only —
+     * never [content] (ciphertext), which would produce an undecryptable note with the real passphrase.
+     */
+    internal fun resolvePlaintextForEncrypt(): String? {
+        val raw =
+            when {
+                isEncrypted -> _decryptedContent.value
+                else -> displayContent ?: _content.value
+            } ?: return null
+        return stripInvisibleUnicode(stripInvisibleFromEdges(raw))
+    }
 
     class Factory(
         private val note: Note,

--- a/app/src/main/java/com/jotty/android/ui/notes/WysiwygNoteEditor.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/WysiwygNoteEditor.kt
@@ -67,6 +67,7 @@ internal fun WysiwygNoteEditor(
     onCategoryChange: ((String) -> Unit)? = null,
     categorySuggestions: List<String> = emptyList(),
     showHtmlSaveHint: Boolean = false,
+    onEditorWebView: (android.webkit.WebView?) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var editorWebView by remember { mutableStateOf<WebView?>(null) }
@@ -128,7 +129,10 @@ internal fun WysiwygNoteEditor(
             borderColor = borderColor,
             onContentChange = onContentChange,
             onFormatStateChange = { formatState = it },
-            onWebViewReady = { editorWebView = it },
+            onWebViewReady = {
+                editorWebView = it
+                onEditorWebView(it)
+            },
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,7 @@
     <string name="decrypt_error_show_details">Details</string>
     <string name="decrypt_error_hide_details">Hide details</string>
     <string name="error_encrypt_failed">Encryption failed. Please try again.</string>
+    <string name="error_encrypt_no_plaintext">Could not read the note text to encrypt. Unlock the note again and retry.</string>
     <string name="note_is_encrypted">This note is encrypted</string>
     <string name="pgp_not_supported">PGP decryption is not supported in the app. Use the Jotty web app to decrypt.</string>
     <string name="enter_passphrase_to_view">Enter your passphrase to view the content.</string>

--- a/app/src/test/java/com/jotty/android/data/encryption/NoteEncryptionTest.kt
+++ b/app/src/test/java/com/jotty/android/data/encryption/NoteEncryptionTest.kt
@@ -106,6 +106,26 @@ class NoteEncryptionTest {
         assertTrue(result is ParsedNoteContent.Encrypted)
     }
 
+    @Test
+    fun `parse handles title containing frontmatter delimiter`() {
+        val body = """{"alg":"xchacha20","salt":"abc","nonce":"def","data":"ghi"}"""
+        val content =
+            """
+            |---
+            |uuid: note-1
+            |title: "Section --- notes"
+            |encrypted: true
+            |encryptionMethod: xchacha
+            |---
+            |$body
+            """.trimMargin()
+        val result = NoteEncryption.parse(content)
+        assertTrue(result is ParsedNoteContent.Encrypted)
+        val enc = result as ParsedNoteContent.Encrypted
+        assertEquals(body, enc.encryptedBody)
+        assertEquals("Section --- notes", enc.frontmatter.title)
+    }
+
     // ── parse: body-only xchacha JSON ───────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/jotty/android/data/encryption/XChaCha20EncryptorTest.kt
+++ b/app/src/test/java/com/jotty/android/data/encryption/XChaCha20EncryptorTest.kt
@@ -11,6 +11,33 @@ import java.util.Base64
 @Config(sdk = [34])
 class XChaCha20EncryptorTest {
     @Test
+    fun `wrapWithFrontmatter quotes title containing frontmatter delimiter`() {
+        val body = """{"alg":"xchacha20","salt":"abc","nonce":"def","data":"ghi"}"""
+        val wrapped =
+            XChaCha20Encryptor.wrapWithFrontmatter(
+                "note-1",
+                "Section --- notes",
+                "Work",
+                body,
+            )
+        val parsed = NoteEncryption.parse(wrapped)
+        assertTrue(parsed is ParsedNoteContent.Encrypted)
+        val enc = parsed as ParsedNoteContent.Encrypted
+        assertEquals(body, enc.encryptedBody)
+        assertEquals("Section --- notes", enc.frontmatter.title)
+    }
+
+    @Test
+    fun `yamlScalar leaves simple titles unquoted`() {
+        assertEquals("My Title", XChaCha20Encryptor.yamlScalar("My Title"))
+    }
+
+    @Test
+    fun `yamlScalar quotes titles with colons`() {
+        assertEquals("\"My: Title\"", XChaCha20Encryptor.yamlScalar("My: Title"))
+    }
+
+    @Test
     fun `wrapWithFrontmatter produces valid YAML frontmatter`() {
         val body = """{"alg":"xchacha20","salt":"abc","nonce":"def","data":"ghi"}"""
         val result = XChaCha20Encryptor.wrapWithFrontmatter("note-1", "My Title", "Work", body)

--- a/app/src/test/java/com/jotty/android/ui/notes/NotesViewModelsTest.kt
+++ b/app/src/test/java/com/jotty/android/ui/notes/NotesViewModelsTest.kt
@@ -218,6 +218,42 @@ class NoteDetailViewModelTest {
     }
 
     @Test
+    fun resolvePlaintextForEncrypt_encryptedNote_usesDecryptedNotCiphertext() {
+        val ciphertext =
+            "---\nencrypted: true\nencryptionMethod: xchacha\n---\n" +
+                """{"alg":"xchacha20","salt":"aa","nonce":"bb","data":"cc"}"""
+        val note =
+            Note(
+                id = "n-enc",
+                title = "Secrets",
+                category = API_CATEGORY_UNCATEGORIZED,
+                content = ciphertext,
+                createdAt = "c",
+                updatedAt = "u",
+                encrypted = true,
+            )
+        val vm =
+            NoteDetailViewModel(
+                note,
+                object : NoteDetailActions {
+                    override suspend fun updateNote(
+                        noteId: String,
+                        title: String,
+                        content: String,
+                        category: String,
+                        originalCategory: String,
+                    ): Result<Note> = Result.failure(UnsupportedOperationException())
+
+                    override suspend fun deleteNote(noteId: String): Result<Unit> =
+                        Result.failure(UnsupportedOperationException())
+                },
+            )
+        assertNull(vm.resolvePlaintextForEncrypt())
+        vm.onDecrypted("Edited body", passphrase = "my-long-passphrase".toCharArray())
+        assertEquals("Edited body", vm.resolvePlaintextForEncrypt())
+    }
+
+    @Test
     fun onDecrypted_storesPassphraseInSession() {
         val note =
             Note(


### PR DESCRIPTION
## Summary

Fixes #67 — critical bug where saving an edited encrypted note could produce undecryptable ciphertext on the server (app and Jotty web both report incorrect passphrase).

- Re-encrypt requires session plaintext; never falls back to stored ciphertext
- Refuses save when plaintext is missing or looks like encrypted content
- Flushes WYSIWYG WebView HTML before opening the encrypt/save dialog
- YAML-quotes frontmatter scalars; parses closing `---` only on its own line
- Stores trimmed passphrase in session after decrypt (consistent with encrypt)

## Test plan

- [x] `XChaCha20EncryptorTest` — frontmatter quoting and round-trip
- [x] `NoteEncryptionTest` — title containing `---`
- [x] `NoteDetailViewModelTest` — re-encrypt uses decrypted body, not ciphertext
- [ ] Manual: decrypt encrypted note → edit in visual editor → save → decrypt again with same passphrase
- [ ] Manual: decrypt → edit title with `---` → save → decrypt on web
