### PR TITLE
Release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Fixed
 
+- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Fixed
 
-- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body.
+- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body. Before saving, the app now decrypts the freshly encrypted note locally and aborts the save if it cannot be read back, so a note that fails to decrypt is never pushed to the server.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Fixed
+
+- **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
+
 ---
 
 ## [1.7.0] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+---
+
+## [1.7.1] - 2026-06-17
+
 ### Fixed
 
 - **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body. Before saving, the app now decrypts the freshly encrypted note locally and aborts the save if it cannot be read back, so a note that fails to decrypt is never pushed to the server.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
+
 
 ---
 
@@ -984,3 +989,5 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 [1.6.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.6.0
 
 [1.7.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.0
+
+[1.7.1]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.1

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,10 +6,15 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+---
+
+## [1.7.1] - 2026-06-17
+
 ### Fixed
 
 - **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body. Before saving, the app now decrypts the freshly encrypted note locally and aborts the save if it cannot be read back, so a note that fails to decrypt is never pushed to the server.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
+
 
 ---
 
@@ -984,3 +989,5 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 [1.6.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.6.0
 
 [1.7.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.0
+
+[1.7.1]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.1

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -8,7 +8,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Fixed
 
-- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt now requires decrypted body text; frontmatter titles with `---` or colons are YAML-quoted so the encrypted JSON body is not truncated on parse.
+- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt requires decrypted body text; YAML frontmatter quoting and line-based `---` parsing prevent titles containing `---` from truncating the encrypted JSON body. Before saving, the app now decrypts the freshly encrypted note locally and aborts the save if it cannot be read back, so a note that fails to decrypt is never pushed to the server.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
 
 ---

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -8,6 +8,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Fixed
 
+- **Encrypted note save corrupting ciphertext** — Saving an edited encrypted note no longer re-encrypts the stored ciphertext when session plaintext is missing (e.g. visual editor not flushed, or unlock state lost). Re-encrypt now requires decrypted body text; frontmatter titles with `---` or colons are YAML-quoted so the encrypted JSON body is not truncated on parse.
 - **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
 
 ---

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,29 +6,41 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Fixed
+
+- **Stable release publish** — `publish-release.ps1 -LocalBuild` reads the APK path from the last line of build script output so Gradle logs no longer break `gh release upload`.
+
+---
+
+## [1.7.0] - 2026-06-17
+
 ### Added
 
-- **Auto dev-latest on push** — After `setup-repo-git`, a pre-push hook builds and publishes the rolling [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest) release locally when you push to `dev` (no GitHub Actions). Log: `.git/jotty-dev-publish.log`; skip with `git push --no-verify` or `git config jotty.autoPublishDev false`.
-- **Kanban item rich fields** — On Jotty servers with expanded item REST support (develop+), task detail lets you edit priority, score, start/target dates, estimated time, and view metadata (created/modified, status history). Description read-back works on supported servers. Older servers keep disabled placeholders ([#52](https://github.com/Darknetzz/jotty-android/issues/52)).
-- **Local CI and builds** — Run tests, lint, ktlint, and APK builds on your machine instead of GitHub Actions: `scripts/ci-local.ps1`, `build-dev-apk`, `build-release-apk`, and `publish-dev-latest`. See [docs/LOCAL_CI.md](docs/LOCAL_CI.md). GitHub workflows are manual-only; use `publish-release.ps1 -LocalBuild` for stable releases without Actions.
-
+- **Kanban item rich fields** — On Jotty servers with expanded item REST support (develop+), task detail lets you edit priority, score, start/target dates, estimated time, and view metadata (created/modified, status history). Description read-back works on supported servers. Older servers keep disabled placeholders (see [server compatibility](docs/JOTTY_SERVER_COMPATIBILITY.md)).
 - **Pending sync badge** — Notes and checklists with unsynced local changes show a compact **Pending sync** badge on list cards.
 - **Encrypted note offline hint** — Opening an encrypted note while offline (without a remembered passphrase) shows a dedicated explanation instead of the generic decrypt prompt alone.
 - **Offline category filter snackbar** — Selecting a category with no items on this device yet shows a snackbar prompting sync when online.
+- **WYSIWYG editor toolbar** — Formatting actions use compact icon buttons in a scrollable row (underline, strikethrough, code, quote, image, table); toolbar buttons highlight based on the current cursor/selection formatting.
 
-### Fixed
+### Changed
 
-- **Dev-latest publish scripts** — PowerShell `gh release create` now uses `--notes-file` (multiline notes no longer break the command) and reads the APK path from build script output; bash build script emits the path on stdout only. Git Bash hook builds now unescape Windows `sdk.dir` paths in `local.properties`. — Formatting actions use compact icon buttons (matching the markdown toolbar) in a scrollable row so controls no longer clip off-screen; added underline, strikethrough, code, quote, image, and table actions. Toolbar buttons now highlight based on the current cursor/selection formatting.
-- **Dependencies** — Bumped Coil (2.7), Bouncy Castle (1.84), Activity Compose (1.13), reorderable (3.1.0), and AndroidX test runner (1.7.0). Kept core-ktx 1.18 (1.19 needs compileSdk 37), OkHttp 4.x, ktlint 12.x, and Kotlin 2.3.x until coordinated upgrades.
-- **Dependabot** — Grouped weekly Gradle and GitHub Actions updates into one PR per ecosystem (plus a separate major-version group); ignore rules skip blocked core-ktx, ktlint 14+, OkHttp 5, and Kotlin 2.4+ until ready.
-- **Architecture** — Extracted `SettingsViewModel`, `SetupViewModel`, and `ChecklistDetailViewModel`; notes list passes per-note unlock state to avoid recomposition on every decrypt.
 - **Checklist auto-emoji** — Keyword emoji prefixes apply to simple checklists only; project/Kanban boards, list view, and task detail no longer show auto-emoji (manual emoji in item text still renders).
+- **Dependencies** — Bumped Coil (2.7), Bouncy Castle (1.84), Activity Compose (1.13), reorderable (3.1.0), and AndroidX test runner (1.7.0). Kept core-ktx 1.18 (1.19 needs compileSdk 37), OkHttp 4.x, ktlint 12.x, and Kotlin 2.3.x until coordinated upgrades.
 
 ### Fixed
 
 - **TalkBack** — Kanban card menu and item-detail delete actions expose content descriptions.
+- **Dev-latest publish scripts** — PowerShell `gh release create` now uses `--notes-file` (multiline notes no longer break the command) and reads the APK path from build script output; bash build script emits the path on stdout only. Git Bash hook builds now unescape Windows `sdk.dir` paths in `local.properties`.
+
+### Documentation
+
+- **Auto dev-latest on push** — After `setup-repo-git`, a pre-push hook builds and publishes the rolling [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest) release locally when you push to `dev` (no GitHub Actions). Log: `.git/jotty-dev-publish.log`; skip with `git push --no-verify` or `git config jotty.autoPublishDev false`.
+- **Local CI and builds** — Run tests, lint, ktlint, and APK builds on your machine instead of GitHub Actions: `scripts/ci-local.ps1`, `build-dev-apk`, `build-release-apk`, and `publish-dev-latest`. See [docs/LOCAL_CI.md](docs/LOCAL_CI.md). GitHub workflows are manual-only; use `publish-release.ps1 -LocalBuild` for stable releases without Actions.
+- **Dependabot** — Grouped weekly Gradle and GitHub Actions updates into one PR per ecosystem (plus a separate major-version group); ignore rules skip blocked core-ktx, ktlint 14+, OkHttp 5, and Kotlin 2.4+ until ready.
+
 
 ---
+
 ## [1.6.0] - 2026-06-09
 
 ### Added
@@ -969,3 +981,5 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 [1.5.2]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.5.2
 
 [1.6.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.6.0
+
+[1.7.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.0

--- a/app/src/main/java/com/jotty/android/data/encryption/NoteEncryption.kt
+++ b/app/src/main/java/com/jotty/android/data/encryption/NoteEncryption.kt
@@ -45,7 +45,7 @@ object NoteEncryption {
         // 1) Frontmatter format: --- ... encrypted: true ... --- \n body
         if (trimmed.startsWith(FRONTMATTER_START)) {
             val afterFirst = trimmed.substring(FRONTMATTER_START.length)
-            val endOfFront = afterFirst.indexOf(FRONTMATTER_END)
+            val endOfFront = findFrontmatterEnd(afterFirst)
             if (endOfFront != -1) {
                 val frontmatterStr = afterFirst.substring(0, endOfFront).trim().replace("\r\n", "\n").replace("\r", "\n")
                 val body = afterFirst.substring(endOfFront + FRONTMATTER_END.length).trim()
@@ -81,4 +81,14 @@ object NoteEncryption {
      * Returns true if [content] is an encrypted note (frontmatter or encrypted JSON body).
      */
     fun isEncrypted(content: String): Boolean = parse(content) is ParsedNoteContent.Encrypted
+
+    /**
+     * Closing `---` must be on its own line so titles/values containing `---` do not truncate the body.
+     */
+    private fun findFrontmatterEnd(afterOpeningDelimiter: String): Int {
+        val normalized = afterOpeningDelimiter.replace("\r\n", "\n").replace("\r", "\n")
+        val regex = Regex("""\n---(?:\n|$)""")
+        val match = regex.find(normalized) ?: return -1
+        return match.range.first + 1 // skip leading newline; points at closing ---
+    }
 }

--- a/app/src/main/java/com/jotty/android/data/encryption/XChaCha20Encryptor.kt
+++ b/app/src/main/java/com/jotty/android/data/encryption/XChaCha20Encryptor.kt
@@ -89,6 +89,7 @@ object XChaCha20Encryptor {
 
     /**
      * Builds full note content with YAML frontmatter for Jotty (encrypted: true, encryptionMethod: xchacha).
+     * Title and uuid are quoted when needed so values containing `---` or colons do not break parsing.
      */
     fun wrapWithFrontmatter(
         noteId: String,
@@ -96,15 +97,32 @@ object XChaCha20Encryptor {
         category: String,
         encryptedBodyJson: String,
     ): String {
+        val safeUuid = yamlScalar(noteId)
+        val safeTitle = yamlScalar(noteTitle)
         return """
             |---
-            |uuid: $noteId
-            |title: $noteTitle
+            |uuid: $safeUuid
+            |title: $safeTitle
             |encrypted: true
             |encryptionMethod: xchacha
             |---
             |$encryptedBodyJson
             """.trimMargin()
+    }
+
+    /** YAML scalar for frontmatter; double-quoted when special characters would confuse [NoteEncryption.parse]. */
+    internal fun yamlScalar(value: String): String {
+        if (value.isEmpty()) return "\"\""
+        val needsQuotes =
+            value.any { it == '\n' || it == '\r' || it == ':' || it == '#' } ||
+                value.contains("---") ||
+                value != value.trim() ||
+                value.any { it == '"' || it == '\\' }
+        return if (needsQuotes) {
+            "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        } else {
+            value
+        }
     }
 
     /**

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.jotty.android.ui.notes
 
 import android.content.ClipData
+import android.webkit.WebView
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
@@ -136,6 +137,7 @@ internal fun NoteDetailScreen(
 
     var noteEditMode by rememberSaveable(note.id) { mutableStateOf(NoteEditMode.Markdown) }
     var editorReloadNonce by rememberSaveable(note.id) { mutableIntStateOf(0) }
+    var wysiwygWebView by remember(note.id) { mutableStateOf<WebView?>(null) }
 
     fun currentEditBody(): String = if (isEncrypted) decryptedContent.orEmpty() else content
 
@@ -144,6 +146,17 @@ internal fun NoteDetailScreen(
             detailVm.setDecryptedContent(value)
         } else {
             detailVm.setContent(value)
+        }
+    }
+
+    fun initiateEncryptedSave() {
+        if (noteEditMode == NoteEditMode.Visual) {
+            getWysiwygContent(wysiwygWebView) { html ->
+                setEditBody(html)
+                detailVm.showEncryptDialog()
+            }
+        } else {
+            detailVm.showEncryptDialog()
         }
     }
 
@@ -391,7 +404,7 @@ internal fun NoteDetailScreen(
                             IconButton(
                                 onClick = {
                                     if (isEncrypted) {
-                                        detailVm.showEncryptDialog()
+                                        initiateEncryptedSave()
                                     } else {
                                         detailVm.saveEdit(
                                             onSuccess = onUpdate,
@@ -569,6 +582,7 @@ internal fun NoteDetailScreen(
                                     onCategoryChange = { detailVm.setCategory(it) },
                                     categorySuggestions = categorySuggestions,
                                     showHtmlSaveHint = noteContentContainsRawHtml(editBody),
+                                    onEditorWebView = { wysiwygWebView = it },
                                     modifier = Modifier.fillMaxSize(),
                                 )
                             NoteEditMode.Markdown ->
@@ -653,6 +667,7 @@ internal fun NoteDetailScreen(
 
     if (showEncryptDialog) {
         val encryptFailedMsg = stringResource(R.string.error_encrypt_failed)
+        val encryptNoPlaintextMsg = stringResource(R.string.error_encrypt_no_plaintext)
         val reEncryptMode = isEncrypted && detailVm.hasSessionPassphrase()
         EncryptNoteDialog(
             onDismiss = { detailVm.dismissEncryptDialog() },
@@ -664,6 +679,7 @@ internal fun NoteDetailScreen(
                     encryptFailedMsg,
                     onSuccess = onUpdate,
                     onFailure = onSaveFailed,
+                    encryptNoPlaintextMsg = encryptNoPlaintextMsg,
                 )
             },
             onEncrypt = { passChars ->
@@ -672,6 +688,7 @@ internal fun NoteDetailScreen(
                     encryptFailedMsg,
                     onSuccess = onUpdate,
                     onFailure = onSaveFailed,
+                    encryptNoPlaintextMsg = encryptNoPlaintextMsg,
                 )
             },
         )

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.jotty.android.data.encryption.NoteEncryption
 import com.jotty.android.data.encryption.ParsedNoteContent
 import com.jotty.android.data.encryption.XChaCha20Encryptor
 import com.jotty.android.data.encryption.clearPassphrase
+import com.jotty.android.data.encryption.copyTrimmedOrNull
 import com.jotty.android.util.AppLog
 import com.jotty.android.util.stripInvisibleFromEdges
 import com.jotty.android.util.stripInvisibleUnicode
@@ -156,13 +157,14 @@ class NoteDetailViewModel(
         encryptFailedMsg: String,
         onSuccess: (Note) -> Unit,
         onFailure: () -> Unit,
+        encryptNoPlaintextMsg: String? = null,
     ) {
         val passChars = NotePassphraseSession.get(activeNoteId)
         if (passChars == null) {
             showEncryptDialog()
             return
         }
-        encrypt(passChars, encryptFailedMsg, onSuccess, onFailure)
+        encrypt(passChars, encryptFailedMsg, onSuccess, onFailure, encryptNoPlaintextMsg)
     }
 
     fun setTitle(value: String) {
@@ -227,8 +229,10 @@ class NoteDetailViewModel(
         _legacyEncryptionDetected.value = usedLegacyDataOrder
         sessionSourceFingerprint = contentFingerprint(_content.value)
         NoteDecryptionSession.put(activeNoteId, cleaned)
-        passphrase?.let { NotePassphraseSession.put(activeNoteId, it) }
-        passphrase?.clearPassphrase()
+        passphrase?.copyTrimmedOrNull()?.let { trimmed ->
+            NotePassphraseSession.put(activeNoteId, trimmed)
+            passphrase.clearPassphrase()
+        } ?: passphrase?.clearPassphrase()
         dismissDecryptDialog()
     }
 
@@ -272,14 +276,28 @@ class NoteDetailViewModel(
         encryptFailedMsg: String,
         onSuccess: (Note) -> Unit,
         onFailure: () -> Unit,
+        encryptNoPlaintextMsg: String? = null,
     ) {
         viewModelScope.launch {
             _encryptError.value = null
             _isEncrypting.value = true
-            val plainToEncrypt =
-                stripInvisibleUnicode(
-                    stripInvisibleFromEdges(displayContent ?: _content.value),
+            val plainToEncrypt = resolvePlaintextForEncrypt()
+            if (plainToEncrypt == null) {
+                _encryptError.value = encryptNoPlaintextMsg ?: encryptFailedMsg
+                passChars.clearPassphrase()
+                _isEncrypting.value = false
+                return@launch
+            }
+            if (isEncrypted && NoteEncryption.isEncrypted(plainToEncrypt)) {
+                AppLog.e(
+                    "encryption",
+                    "Refusing to re-encrypt ciphertext as plaintext for note $activeNoteId",
                 )
+                _encryptError.value = encryptNoPlaintextMsg ?: encryptFailedMsg
+                passChars.clearPassphrase()
+                _isEncrypting.value = false
+                return@launch
+            }
             try {
                 val body =
                     withContext(Dispatchers.Default) {
@@ -368,6 +386,19 @@ class NoteDetailViewModel(
 
     internal fun contentFingerprint(content: String): String =
         stripInvisibleFromEdges(content).hashCode().toString()
+
+    /**
+     * Plaintext to encrypt. Re-encrypting an already encrypted note must use session plaintext only —
+     * never [content] (ciphertext), which would produce an undecryptable note with the real passphrase.
+     */
+    internal fun resolvePlaintextForEncrypt(): String? {
+        val raw =
+            when {
+                isEncrypted -> _decryptedContent.value
+                else -> displayContent ?: _content.value
+            } ?: return null
+        return stripInvisibleUnicode(stripInvisibleFromEdges(raw))
+    }
 
     class Factory(
         private val note: Note,

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.jotty.android.data.encryption.NoteDecryptionSession
 import com.jotty.android.data.encryption.NotePassphraseSession
 import com.jotty.android.data.encryption.NoteEncryption
 import com.jotty.android.data.encryption.ParsedNoteContent
+import com.jotty.android.data.encryption.XChaCha20Decryptor
 import com.jotty.android.data.encryption.XChaCha20Encryptor
 import com.jotty.android.data.encryption.clearPassphrase
 import com.jotty.android.data.encryption.copyTrimmedOrNull
@@ -311,6 +312,21 @@ class NoteDetailViewModel(
                             _category.value,
                             body,
                         )
+                    // Safety net (issue #67): never push ciphertext we cannot read back.
+                    // Round-trip decrypt the freshly produced body (and the wrapped form) with the
+                    // same passphrase before saving; abort if it does not match the plaintext.
+                    val roundTripsOk =
+                        withContext(Dispatchers.Default) {
+                            verifyEncryptRoundTrip(body, fullContent, plainToEncrypt, passChars)
+                        }
+                    if (!roundTripsOk) {
+                        AppLog.e(
+                            "encryption",
+                            "Aborting save: re-encrypted note $activeNoteId failed local round-trip decrypt",
+                        )
+                        _encryptError.value = encryptFailedMsg
+                        return@launch
+                    }
                     val result =
                         actions.updateNote(
                             noteId = activeNoteId,
@@ -386,6 +402,24 @@ class NoteDetailViewModel(
 
     internal fun contentFingerprint(content: String): String =
         stripInvisibleFromEdges(content).hashCode().toString()
+
+    /**
+     * Decrypts the freshly produced [body] (and the frontmatter-wrapped [fullContent]) with [passChars]
+     * and confirms the result matches [expectedPlaintext]. Guards against pushing undecryptable ciphertext
+     * (issue #67). Uses passphrase copies so the caller's buffer survives for the session store.
+     */
+    internal fun verifyEncryptRoundTrip(
+        body: String,
+        fullContent: String,
+        expectedPlaintext: String,
+        passChars: CharArray,
+    ): Boolean {
+        val fromBody = XChaCha20Decryptor.decrypt(body, passChars.copyOf())
+        if (fromBody != expectedPlaintext) return false
+        val parsed = NoteEncryption.parse(fullContent) as? ParsedNoteContent.Encrypted ?: return false
+        val fromWrapped = XChaCha20Decryptor.decrypt(parsed.encryptedBody, passChars.copyOf())
+        return fromWrapped == expectedPlaintext
+    }
 
     /**
      * Plaintext to encrypt. Re-encrypting an already encrypted note must use session plaintext only —

--- a/app/src/main/java/com/jotty/android/ui/notes/WysiwygNoteEditor.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/WysiwygNoteEditor.kt
@@ -67,6 +67,7 @@ internal fun WysiwygNoteEditor(
     onCategoryChange: ((String) -> Unit)? = null,
     categorySuggestions: List<String> = emptyList(),
     showHtmlSaveHint: Boolean = false,
+    onEditorWebView: (android.webkit.WebView?) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var editorWebView by remember { mutableStateOf<WebView?>(null) }
@@ -128,7 +129,10 @@ internal fun WysiwygNoteEditor(
             borderColor = borderColor,
             onContentChange = onContentChange,
             onFormatStateChange = { formatState = it },
-            onWebViewReady = { editorWebView = it },
+            onWebViewReady = {
+                editorWebView = it
+                onEditorWebView(it)
+            },
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,7 @@
     <string name="decrypt_error_show_details">Details</string>
     <string name="decrypt_error_hide_details">Hide details</string>
     <string name="error_encrypt_failed">Encryption failed. Please try again.</string>
+    <string name="error_encrypt_no_plaintext">Could not read the note text to encrypt. Unlock the note again and retry.</string>
     <string name="note_is_encrypted">This note is encrypted</string>
     <string name="pgp_not_supported">PGP decryption is not supported in the app. Use the Jotty web app to decrypt.</string>
     <string name="enter_passphrase_to_view">Enter your passphrase to view the content.</string>

--- a/app/src/test/java/com/jotty/android/data/encryption/NoteEncryptionTest.kt
+++ b/app/src/test/java/com/jotty/android/data/encryption/NoteEncryptionTest.kt
@@ -106,6 +106,26 @@ class NoteEncryptionTest {
         assertTrue(result is ParsedNoteContent.Encrypted)
     }
 
+    @Test
+    fun `parse handles title containing frontmatter delimiter`() {
+        val body = """{"alg":"xchacha20","salt":"abc","nonce":"def","data":"ghi"}"""
+        val content =
+            """
+            |---
+            |uuid: note-1
+            |title: "Section --- notes"
+            |encrypted: true
+            |encryptionMethod: xchacha
+            |---
+            |$body
+            """.trimMargin()
+        val result = NoteEncryption.parse(content)
+        assertTrue(result is ParsedNoteContent.Encrypted)
+        val enc = result as ParsedNoteContent.Encrypted
+        assertEquals(body, enc.encryptedBody)
+        assertEquals("Section --- notes", enc.frontmatter.title)
+    }
+
     // ── parse: body-only xchacha JSON ───────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/jotty/android/data/encryption/XChaCha20EncryptorTest.kt
+++ b/app/src/test/java/com/jotty/android/data/encryption/XChaCha20EncryptorTest.kt
@@ -11,6 +11,33 @@ import java.util.Base64
 @Config(sdk = [34])
 class XChaCha20EncryptorTest {
     @Test
+    fun `wrapWithFrontmatter quotes title containing frontmatter delimiter`() {
+        val body = """{"alg":"xchacha20","salt":"abc","nonce":"def","data":"ghi"}"""
+        val wrapped =
+            XChaCha20Encryptor.wrapWithFrontmatter(
+                "note-1",
+                "Section --- notes",
+                "Work",
+                body,
+            )
+        val parsed = NoteEncryption.parse(wrapped)
+        assertTrue(parsed is ParsedNoteContent.Encrypted)
+        val enc = parsed as ParsedNoteContent.Encrypted
+        assertEquals(body, enc.encryptedBody)
+        assertEquals("Section --- notes", enc.frontmatter.title)
+    }
+
+    @Test
+    fun `yamlScalar leaves simple titles unquoted`() {
+        assertEquals("My Title", XChaCha20Encryptor.yamlScalar("My Title"))
+    }
+
+    @Test
+    fun `yamlScalar quotes titles with colons`() {
+        assertEquals("\"My: Title\"", XChaCha20Encryptor.yamlScalar("My: Title"))
+    }
+
+    @Test
     fun `wrapWithFrontmatter produces valid YAML frontmatter`() {
         val body = """{"alg":"xchacha20","salt":"abc","nonce":"def","data":"ghi"}"""
         val result = XChaCha20Encryptor.wrapWithFrontmatter("note-1", "My Title", "Work", body)

--- a/app/src/test/java/com/jotty/android/ui/notes/NotesViewModelsTest.kt
+++ b/app/src/test/java/com/jotty/android/ui/notes/NotesViewModelsTest.kt
@@ -6,7 +6,11 @@ import androidx.test.core.app.ApplicationProvider
 import com.jotty.android.data.api.API_CATEGORY_UNCATEGORIZED
 import com.jotty.android.data.api.Note
 import com.jotty.android.data.encryption.NoteDecryptionSession
+import com.jotty.android.data.encryption.NoteEncryption
 import com.jotty.android.data.encryption.NotePassphraseSession
+import com.jotty.android.data.encryption.ParsedNoteContent
+import com.jotty.android.data.encryption.XChaCha20Decryptor
+import com.jotty.android.data.encryption.XChaCha20Encryptor
 import com.jotty.android.data.encryption.clearPassphrase
 import com.jotty.android.data.local.FakeJottyApi
 import com.jotty.android.data.local.JottyDatabase
@@ -15,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -215,6 +220,64 @@ class NoteDetailViewModelTest {
         assertNull(vm.decryptedContent.value)
         assertNull(NoteDecryptionSession.get(note.id))
         assertNull(NotePassphraseSession.get(note.id))
+    }
+
+    private fun encryptedNoteViewModel(content: String): NoteDetailViewModel {
+        val note =
+            Note(
+                id = "n-enc",
+                title = "Secret --- note",
+                category = "Work",
+                content = content,
+                createdAt = "c",
+                updatedAt = "u",
+                encrypted = true,
+            )
+        return NoteDetailViewModel(
+            note,
+            object : NoteDetailActions {
+                override suspend fun updateNote(
+                    noteId: String,
+                    title: String,
+                    content: String,
+                    category: String,
+                    originalCategory: String,
+                ): Result<Note> = Result.failure(UnsupportedOperationException())
+
+                override suspend fun deleteNote(noteId: String): Result<Unit> =
+                    Result.failure(UnsupportedOperationException())
+            },
+        )
+    }
+
+    @Test
+    fun verifyEncryptRoundTrip_acceptsFreshlyEncryptedBodyWithDelimiterTitle() {
+        val passphrase = "my secure passphrase 123"
+        val plaintext = "Edited body with a title containing --- delimiters"
+        val body = XChaCha20Encryptor.encrypt(plaintext, passphrase)!!
+        val wrapped = XChaCha20Encryptor.wrapWithFrontmatter("n-enc", "Secret --- note", "Work", body)
+        val vm = encryptedNoteViewModel(wrapped)
+
+        assertTrue(
+            "freshly encrypted body must round-trip decrypt to the same plaintext",
+            vm.verifyEncryptRoundTrip(body, wrapped, plaintext, passphrase.toCharArray()),
+        )
+        // Sanity: the wrapped form still parses as encrypted and decrypts independently.
+        val parsed = NoteEncryption.parse(wrapped)
+        assertTrue(parsed is ParsedNoteContent.Encrypted)
+        assertEquals(plaintext, XChaCha20Decryptor.decrypt((parsed as ParsedNoteContent.Encrypted).encryptedBody, passphrase))
+    }
+
+    @Test
+    fun verifyEncryptRoundTrip_rejectsTamperedBody() {
+        val passphrase = "my secure passphrase 123"
+        val plaintext = "Edited body"
+        val body = XChaCha20Encryptor.encrypt(plaintext, passphrase)!!
+        val wrapped = XChaCha20Encryptor.wrapWithFrontmatter("n-enc", "Secret", "Work", body)
+        val vm = encryptedNoteViewModel(wrapped)
+
+        // Wrong expected plaintext simulates a body that does not match what we intended to save.
+        assertFalse(vm.verifyEncryptRoundTrip(body, wrapped, "different plaintext", passphrase.toCharArray()))
     }
 
     @Test

--- a/app/src/test/java/com/jotty/android/ui/notes/NotesViewModelsTest.kt
+++ b/app/src/test/java/com/jotty/android/ui/notes/NotesViewModelsTest.kt
@@ -218,6 +218,42 @@ class NoteDetailViewModelTest {
     }
 
     @Test
+    fun resolvePlaintextForEncrypt_encryptedNote_usesDecryptedNotCiphertext() {
+        val ciphertext =
+            "---\nencrypted: true\nencryptionMethod: xchacha\n---\n" +
+                """{"alg":"xchacha20","salt":"aa","nonce":"bb","data":"cc"}"""
+        val note =
+            Note(
+                id = "n-enc",
+                title = "Secrets",
+                category = API_CATEGORY_UNCATEGORIZED,
+                content = ciphertext,
+                createdAt = "c",
+                updatedAt = "u",
+                encrypted = true,
+            )
+        val vm =
+            NoteDetailViewModel(
+                note,
+                object : NoteDetailActions {
+                    override suspend fun updateNote(
+                        noteId: String,
+                        title: String,
+                        content: String,
+                        category: String,
+                        originalCategory: String,
+                    ): Result<Note> = Result.failure(UnsupportedOperationException())
+
+                    override suspend fun deleteNote(noteId: String): Result<Unit> =
+                        Result.failure(UnsupportedOperationException())
+                },
+            )
+        assertNull(vm.resolvePlaintextForEncrypt())
+        vm.onDecrypted("Edited body", passphrase = "my-long-passphrase".toCharArray())
+        assertEquals("Edited body", vm.resolvePlaintextForEncrypt())
+    }
+
+    @Test
     fun onDecrypted_storesPassphraseInSession() {
         val note =
             Note(

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # App version (single source of truth — bump when cutting a release)
-VERSION_NAME=1.7.0
-VERSION_CODE=35
+VERSION_NAME=1.7.1
+VERSION_CODE=36
 
 android.uniquePackageNames=false
 android.r8.strictFullModeForKeepRules=true

--- a/scripts/publish-release.ps1
+++ b/scripts/publish-release.ps1
@@ -213,7 +213,10 @@ if (-not $SkipRelease) {
         Write-Host "Release: https://github.com/Darknetzz/jotty-android/releases/tag/$tag"
         if ($LocalBuild) {
             Write-Host "Building release APK locally..."
-            $apkPath = & (Join-Path $repoRoot "scripts/build-release-apk.ps1") -OutputDir $repoRoot
+            $apkPath = & (Join-Path $repoRoot "scripts/build-release-apk.ps1") -OutputDir $repoRoot | Select-Object -Last 1
+            if (-not (Test-Path -LiteralPath $apkPath)) {
+                throw "Build did not produce APK at: $apkPath"
+            }
             Write-Host "Uploading $apkPath to $tag..."
             gh release upload $tag $apkPath --clobber
             Write-Host "APK attached to release."


### PR DESCRIPTION
## Summary

Stable release **v1.7.1** (gradle.properties / CHANGELOG).

## Test plan

- [ ] CI green on this PR
- [ ] Merge to `main`
- [ ] GitHub release `v1.7.1` published (Release APK workflow attaches APK)
- [ ] `dev` fast-forwards to `main` via sync-dev-with-main workflow

See [CHANGELOG.md](https://github.com/Darknetzz/jotty-android/blob/dev/CHANGELOG.md) on `dev` for full notes.