### PR TITLE
Release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Fixed
+
+- **Visual editor save mangling HTML** — Saving an encrypted note from the WYSIWYG editor no longer stores literal `\u003C` / `\u003E` instead of `<` / `>`; `evaluateJavascript` results are fully JSON-decoded before encrypt. Notes already saved with escaped HTML display correctly after decrypt and can be re-saved to repair the server copy.
+
 ---
 
 ## [1.7.1] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+---
+
+## [1.7.2] - 2026-06-17
+
 ### Fixed
 
 - **Visual editor save mangling HTML** — Saving an encrypted note from the WYSIWYG editor no longer stores literal `\u003C` / `\u003E` instead of `<` / `>`; `evaluateJavascript` results are fully JSON-decoded before encrypt. Notes already saved with escaped HTML display correctly after decrypt and can be re-saved to repair the server copy.
+
 
 ---
 
@@ -995,3 +1000,5 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 [1.7.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.0
 
 [1.7.1]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.1
+
+[1.7.2]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.2

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Fixed
+
+- **Visual editor save mangling HTML** — Saving an encrypted note from the WYSIWYG editor no longer stores literal `\u003C` / `\u003E` instead of `<` / `>`; `evaluateJavascript` results are fully JSON-decoded before encrypt. Notes already saved with escaped HTML display correctly after decrypt and can be re-saved to repair the server copy.
+
 ---
 
 ## [1.7.1] - 2026-06-17

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,9 +6,14 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+---
+
+## [1.7.2] - 2026-06-17
+
 ### Fixed
 
 - **Visual editor save mangling HTML** — Saving an encrypted note from the WYSIWYG editor no longer stores literal `\u003C` / `\u003E` instead of `<` / `>`; `evaluateJavascript` results are fully JSON-decoded before encrypt. Notes already saved with escaped HTML display correctly after decrypt and can be re-saved to repair the server copy.
+
 
 ---
 
@@ -995,3 +1000,5 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 [1.7.0]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.0
 
 [1.7.1]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.1
+
+[1.7.2]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.2

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.jotty.android.data.encryption.XChaCha20Encryptor
 import com.jotty.android.data.encryption.clearPassphrase
 import com.jotty.android.data.encryption.copyTrimmedOrNull
 import com.jotty.android.util.AppLog
+import com.jotty.android.util.decodeJsonUnicodeEscapes
 import com.jotty.android.util.stripInvisibleFromEdges
 import com.jotty.android.util.stripInvisibleUnicode
 import kotlinx.coroutines.Dispatchers
@@ -118,7 +119,11 @@ class NoteDetailViewModel(
     fun loadSessionDecryptedContent() {
         val cached =
             NoteDecryptionSession.get(activeNoteId)
-                ?.let { stripInvisibleUnicode(stripInvisibleFromEdges(it)) }
+                ?.let {
+                    decodeJsonUnicodeEscapes(
+                        stripInvisibleUnicode(stripInvisibleFromEdges(it)),
+                    )
+                }
                 ?.takeIf { it.isNotBlank() }
         _decryptedContent.value = cached
         if (cached == null) {
@@ -217,7 +222,10 @@ class NoteDetailViewModel(
         usedLegacyDataOrder: Boolean = false,
         passphrase: CharArray? = null,
     ) {
-        val cleaned = stripInvisibleUnicode(stripInvisibleFromEdges(plain))
+        val cleaned =
+            decodeJsonUnicodeEscapes(
+                stripInvisibleUnicode(stripInvisibleFromEdges(plain)),
+            )
         if (cleaned.isBlank()) {
             _decryptedContent.value = null
             NoteDecryptionSession.remove(activeNoteId)
@@ -431,7 +439,7 @@ class NoteDetailViewModel(
                 isEncrypted -> _decryptedContent.value
                 else -> displayContent ?: _content.value
             } ?: return null
-        return stripInvisibleUnicode(stripInvisibleFromEdges(raw))
+        return stripInvisibleUnicode(stripInvisibleFromEdges(decodeJsonUnicodeEscapes(raw)))
     }
 
     class Factory(

--- a/app/src/main/java/com/jotty/android/ui/notes/WysiwygFormatState.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/WysiwygFormatState.kt
@@ -1,6 +1,7 @@
 package com.jotty.android.ui.notes
 
 import com.google.gson.Gson
+import com.jotty.android.util.decodeJsonUnicodeEscapes
 
 internal data class WysiwygFormatState(
     val bold: Boolean = false,
@@ -30,9 +31,14 @@ internal fun parseWebViewJsonResult(result: String?): String? {
     if (result.isNullOrBlank() || result == "null") return null
     val trimmed = result.trim()
     if (trimmed.length < 2 || trimmed.first() != '"') return trimmed
-    return trimmed
-        .removeSurrounding("\"")
-        .replace("\\\"", "\"")
-        .replace("\\\\", "\\")
-        .replace("\\n", "\n")
+    return try {
+        wysiwygFormatStateGson.fromJson(trimmed, String::class.java)
+    } catch (_: Exception) {
+        trimmed
+            .removeSurrounding("\"")
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+            .replace("\\n", "\n")
+            .let(::decodeJsonUnicodeEscapes)
+    }
 }

--- a/app/src/main/java/com/jotty/android/ui/notes/WysiwygNoteEditor.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/WysiwygNoteEditor.kt
@@ -312,7 +312,6 @@ private fun WysiwygWebEditor(
 
 fun getWysiwygContent(webView: WebView?, callback: (String) -> Unit) {
     webView?.evaluateJavascript("getContent();") { result ->
-        val unquoted = result?.trim()?.removeSurrounding("\"")?.replace("\\n", "\n")?.replace("\\\"", "\"")
-        callback(unquoted.orEmpty())
+        callback(parseWebViewJsonResult(result).orEmpty())
     }
 }

--- a/app/src/main/java/com/jotty/android/util/Format.kt
+++ b/app/src/main/java/com/jotty/android/util/Format.kt
@@ -49,6 +49,20 @@ fun stripInvisibleFromEdges(s: String): String {
 }
 
 /**
+ * Decodes literal `\\uXXXX` sequences left in note text when [android.webkit.WebView.evaluateJavascript]
+ * results were not fully JSON-unescaped (e.g. HTML saved as `\u003Ctable` instead of `<table>`).
+ * No-op when the string contains no such escapes.
+ */
+fun decodeJsonUnicodeEscapes(s: String): String {
+    if (!s.contains("\\u")) return s
+    return JSON_UNICODE_ESCAPE.replace(s) { match ->
+        match.groupValues[1].toInt(16).toChar().toString()
+    }
+}
+
+private val JSON_UNICODE_ESCAPE = Regex("""\\u([0-9a-fA-F]{4})""")
+
+/**
  * Formats an ISO-style date string (e.g. from API) for display.
  * Returns date part only (YYYY-MM-DD) when possible, otherwise first 10 chars.
  */

--- a/app/src/test/java/com/jotty/android/ui/notes/WysiwygFormatStateTest.kt
+++ b/app/src/test/java/com/jotty/android/ui/notes/WysiwygFormatStateTest.kt
@@ -49,4 +49,10 @@ class WysiwygFormatStateTest {
         val raw = "\"{\\\"bold\\\":true,\\\"italic\\\":false}\""
         assertEquals("{\"bold\":true,\"italic\":false}", parseWebViewJsonResult(raw))
     }
+
+    @Test
+    fun parseWebViewJsonResult_decodesUnicodeEscapedHtml() {
+        val raw = "\"\\u003Ctable\\u003E\\u003Ctd\\u003E\""
+        assertEquals("<table><td>", parseWebViewJsonResult(raw))
+    }
 }

--- a/app/src/test/java/com/jotty/android/util/FormatTest.kt
+++ b/app/src/test/java/com/jotty/android/util/FormatTest.kt
@@ -42,4 +42,15 @@ class FormatTest {
         assertEquals("unchanged", stripInvisibleFromEdges("unchanged"))
         assertEquals("", stripInvisibleFromEdges("\uFEFF\u200B"))
     }
+
+    @Test
+    fun `decodeJsonUnicodeEscapes repairs evaluateJavascript html artifacts`() {
+        val corrupted = """\u003Ctable style="width: 100%;"\u003E\u003Ctd\u003Ecell\u003C/td\u003E"""
+        assertEquals("""<table style="width: 100%;"><td>cell</td>""", decodeJsonUnicodeEscapes(corrupted))
+    }
+
+    @Test
+    fun `decodeJsonUnicodeEscapes no-op without escapes`() {
+        assertEquals("<table><td>ok</td></table>", decodeJsonUnicodeEscapes("<table><td>ok</td></table>"))
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # App version (single source of truth — bump when cutting a release)
-VERSION_NAME=1.7.1
-VERSION_CODE=36
+VERSION_NAME=1.7.2
+VERSION_CODE=37
 
 android.uniquePackageNames=false
 android.r8.strictFullModeForKeepRules=true


### PR DESCRIPTION
## Summary

Stable release **v1.7.2** (gradle.properties / CHANGELOG).

## Test plan

- [ ] CI green on this PR
- [ ] Merge to `main`
- [ ] GitHub release `v1.7.2` published (Release APK workflow attaches APK)
- [ ] `dev` fast-forwards to `main` via sync-dev-with-main workflow

See [CHANGELOG.md](https://github.com/Darknetzz/jotty-android/blob/dev/CHANGELOG.md) on `dev` for full notes.