### PR TITLE
Release v1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Apology
+
+We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some of you lost access to notes you trusted us to keep safe, and that is on us. These hotfixes address undecryptable ciphertext, mangled HTML, unsafe visual-editor saves, and table display issues — but **notes already corrupted on your server cannot be repaired by a passphrase alone**; you may need a Jotty server backup. We should have been far more careful changing how encrypted notes are saved and tested before shipping multiple stable releases. This version adds stronger safeguards, defaults encrypted edits to Markdown, and warns before using the experimental visual editor on encrypted notes. Thank you for reporting the issues and for your patience.
+
 ### Fixed
 
 - **HTML tables rendering as headers** — Jotty web HTML tables (including those wrapped in `<p>` or with `<p>` inside cells) now convert to GFM before other HTML→markdown processing, so cells no longer appear as stacked bold header text in the app reader.
@@ -13,6 +17,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 ### Changed
 
 - **Stable release notes** — GitHub release descriptions no longer include the legacy debug-APK / mixed-signing install warning; in-app update messaging still covers that edge case.
+- **Visual editor on encrypted notes** — Encrypted notes always open in Markdown when editing; switching to Visual requires an explicit risk confirmation and shows a persistent warning banner. Settings copy marks the visual editor as experimental.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+---
+
+## [1.7.4] - 2026-06-17
+
 ### Apology
 
 We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some of you lost access to notes you trusted us to keep safe, and that is on us. These hotfixes address undecryptable ciphertext, mangled HTML, unsafe visual-editor saves, and table display issues — but **notes already corrupted on your server cannot be repaired by a passphrase alone**; you may need a Jotty server backup. We should have been far more careful changing how encrypted notes are saved and tested before shipping multiple stable releases. This version adds stronger safeguards, defaults encrypted edits to Markdown, and warns before using the experimental visual editor on encrypted notes. Thank you for reporting the issues and for your patience.
@@ -18,6 +22,7 @@ We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some 
 
 - **Stable release notes** — GitHub release descriptions no longer include the legacy debug-APK / mixed-signing install warning; in-app update messaging still covers that edge case.
 - **Visual editor on encrypted notes** — Encrypted notes always open in Markdown when editing; switching to Visual requires an explicit risk confirmation and shows a persistent warning banner. Settings copy marks the visual editor as experimental.
+
 
 ---
 
@@ -1026,3 +1031,5 @@ We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some 
 [1.7.2]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.2
 
 [1.7.3]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.3
+
+[1.7.4]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Fixed
+
+- **HTML tables rendering as headers** — Jotty web HTML tables (including those wrapped in `<p>` or with `<p>` inside cells) now convert to GFM before other HTML→markdown processing, so cells no longer appear as stacked bold header text in the app reader.
+
 ---
 
 ## [1.7.3] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 - **HTML tables rendering as headers** — Jotty web HTML tables (including those wrapped in `<p>` or with `<p>` inside cells) now convert to GFM before other HTML→markdown processing, so cells no longer appear as stacked bold header text in the app reader.
 
+### Changed
+
+- **Stable release notes** — GitHub release descriptions no longer include the legacy debug-APK / mixed-signing install warning; in-app update messaging still covers that edge case.
+
 ---
 
 ## [1.7.3] - 2026-06-17

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Apology
+
+We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some of you lost access to notes you trusted us to keep safe, and that is on us. These hotfixes address undecryptable ciphertext, mangled HTML, unsafe visual-editor saves, and table display issues — but **notes already corrupted on your server cannot be repaired by a passphrase alone**; you may need a Jotty server backup. We should have been far more careful changing how encrypted notes are saved and tested before shipping multiple stable releases. This version adds stronger safeguards, defaults encrypted edits to Markdown, and warns before using the experimental visual editor on encrypted notes. Thank you for reporting the issues and for your patience.
+
 ### Fixed
 
 - **HTML tables rendering as headers** — Jotty web HTML tables (including those wrapped in `<p>` or with `<p>` inside cells) now convert to GFM before other HTML→markdown processing, so cells no longer appear as stacked bold header text in the app reader.
@@ -13,6 +17,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 ### Changed
 
 - **Stable release notes** — GitHub release descriptions no longer include the legacy debug-APK / mixed-signing install warning; in-app update messaging still covers that edge case.
+- **Visual editor on encrypted notes** — Encrypted notes always open in Markdown when editing; switching to Visual requires an explicit risk confirmation and shows a persistent warning banner. Settings copy marks the visual editor as experimental.
 
 ---
 

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+---
+
+## [1.7.4] - 2026-06-17
+
 ### Apology
 
 We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some of you lost access to notes you trusted us to keep safe, and that is on us. These hotfixes address undecryptable ciphertext, mangled HTML, unsafe visual-editor saves, and table display issues — but **notes already corrupted on your server cannot be repaired by a passphrase alone**; you may need a Jotty server backup. We should have been far more careful changing how encrypted notes are saved and tested before shipping multiple stable releases. This version adds stronger safeguards, defaults encrypted edits to Markdown, and warns before using the experimental visual editor on encrypted notes. Thank you for reporting the issues and for your patience.
@@ -18,6 +22,7 @@ We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some 
 
 - **Stable release notes** — GitHub release descriptions no longer include the legacy debug-APK / mixed-signing install warning; in-app update messaging still covers that edge case.
 - **Visual editor on encrypted notes** — Encrypted notes always open in Markdown when editing; switching to Visual requires an explicit risk confirmation and shows a persistent warning banner. Settings copy marks the visual editor as experimental.
+
 
 ---
 
@@ -1026,3 +1031,5 @@ We are sincerely sorry for the encrypted-note problems in v1.7.1–v1.7.3. Some 
 [1.7.2]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.2
 
 [1.7.3]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.3
+
+[1.7.4]: https://github.com/Darknetzz/jotty-android/releases/tag/v1.7.4

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -6,6 +6,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ## [dev-latest](https://github.com/Darknetzz/jotty-android/releases/tag/dev-latest)
 
+### Fixed
+
+- **HTML tables rendering as headers** — Jotty web HTML tables (including those wrapped in `<p>` or with `<p>` inside cells) now convert to GFM before other HTML→markdown processing, so cells no longer appear as stacked bold header text in the app reader.
+
 ---
 
 ## [1.7.3] - 2026-06-17

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -10,6 +10,10 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 - **HTML tables rendering as headers** — Jotty web HTML tables (including those wrapped in `<p>` or with `<p>` inside cells) now convert to GFM before other HTML→markdown processing, so cells no longer appear as stacked bold header text in the app reader.
 
+### Changed
+
+- **Stable release notes** — GitHub release descriptions no longer include the legacy debug-APK / mixed-signing install warning; in-app update messaging still covers that edge case.
+
 ---
 
 ## [1.7.3] - 2026-06-17

--- a/app/src/main/java/com/jotty/android/ui/notes/NoteDetailScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/notes/NoteDetailScreen.kt
@@ -139,6 +139,8 @@ internal fun NoteDetailScreen(
     var editorReloadNonce by rememberSaveable(note.id) { mutableIntStateOf(0) }
     var wysiwygWebView by remember(note.id) { mutableStateOf<WebView?>(null) }
     var wysiwygBridge by remember(note.id) { mutableStateOf<WysiwygEditorBridge?>(null) }
+    var encryptedVisualAcknowledged by rememberSaveable(note.id) { mutableStateOf(false) }
+    var showEncryptedVisualConfirm by remember { mutableStateOf(false) }
 
     fun currentEditBody(): String = if (isEncrypted) decryptedContent.orEmpty() else content
 
@@ -161,13 +163,21 @@ internal fun NoteDetailScreen(
         }
     }
 
-    fun onNoteEditModeChange(mode: NoteEditMode) {
-        if (mode == noteEditMode) return
-        if (mode == NoteEditMode.Markdown) {
+    fun applyNoteEditModeChange(mode: NoteEditMode) {
+        if (mode == NoteEditMode.Markdown && noteEditMode == NoteEditMode.Visual) {
             setEditBody(prepareWysiwygHtmlForMarkdown(currentEditBody()))
         }
         noteEditMode = mode
         editorReloadNonce++
+    }
+
+    fun onNoteEditModeChange(mode: NoteEditMode) {
+        if (mode == noteEditMode) return
+        if (mode == NoteEditMode.Visual && isEncrypted && isDecrypted && !encryptedVisualAcknowledged) {
+            showEncryptedVisualConfirm = true
+            return
+        }
+        applyNoteEditModeChange(mode)
     }
 
     val snackbarHostState = remember { SnackbarHostState() }
@@ -250,6 +260,37 @@ internal fun NoteDetailScreen(
 
     LaunchedEffect(note.encrypted, content) {
         detailVm.logEncryptionState()
+    }
+
+    LaunchedEffect(isEditing, isEncrypted, encryptedVisualAcknowledged, noteEditMode) {
+        if (isEditing && isEncrypted && noteEditMode == NoteEditMode.Visual && !encryptedVisualAcknowledged) {
+            noteEditMode = NoteEditMode.Markdown
+            editorReloadNonce++
+        }
+    }
+
+    if (showEncryptedVisualConfirm) {
+        AlertDialog(
+            onDismissRequest = { showEncryptedVisualConfirm = false },
+            title = { Text(stringResource(R.string.encrypted_note_visual_editor_confirm_title)) },
+            text = { Text(stringResource(R.string.encrypted_note_visual_editor_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showEncryptedVisualConfirm = false
+                        encryptedVisualAcknowledged = true
+                        applyNoteEditModeChange(NoteEditMode.Visual)
+                    },
+                ) {
+                    Text(stringResource(R.string.encrypted_note_visual_editor_confirm_continue))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEncryptedVisualConfirm = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
     }
 
     if (showDeleteConfirm) {
@@ -426,6 +467,7 @@ internal fun NoteDetailScreen(
                         IconButton(
                             onClick = {
                                 detailVm.lockNote()
+                                encryptedVisualAcknowledged = false
                                 hasBiometricPassphrase = biometricStore?.hasPassphrase(note.id) == true
                             },
                         ) {
@@ -439,13 +481,18 @@ internal fun NoteDetailScreen(
                     if (!isEditing && canEdit) {
                         IconButton(
                             onClick = {
-                                val body = currentEditBody()
-                                noteEditMode =
-                                    if (richEditorEnabled || noteNeedsRichEditor(body)) {
-                                        NoteEditMode.Visual
-                                    } else {
-                                        NoteEditMode.Markdown
-                                    }
+                                if (isEncrypted) {
+                                    encryptedVisualAcknowledged = false
+                                    noteEditMode = NoteEditMode.Markdown
+                                } else {
+                                    val body = currentEditBody()
+                                    noteEditMode =
+                                        if (richEditorEnabled || noteNeedsRichEditor(body)) {
+                                            NoteEditMode.Visual
+                                        } else {
+                                            NoteEditMode.Markdown
+                                        }
+                                }
                                 editorReloadNonce++
                                 detailVm.startEditing()
                             },
@@ -499,6 +546,7 @@ internal fun NoteDetailScreen(
                                     onClick = {
                                         menuExpanded = false
                                         detailVm.lockNote()
+                                        encryptedVisualAcknowledged = false
                                         hasBiometricPassphrase = biometricStore?.hasPassphrase(note.id) == true
                                     },
                                     leadingIcon = {
@@ -575,6 +623,24 @@ internal fun NoteDetailScreen(
                             mode = noteEditMode,
                             onModeChange = ::onNoteEditModeChange,
                         )
+                        if (isEncrypted && noteEditMode == NoteEditMode.Visual) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Surface(
+                                color = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                shape = MaterialTheme.shapes.small,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.encrypted_note_visual_editor_warning),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                )
+                            }
+                        }
                         Spacer(modifier = Modifier.height(4.dp))
                         when (noteEditMode) {
                             NoteEditMode.Visual ->

--- a/app/src/main/java/com/jotty/android/util/NoteImageUrls.kt
+++ b/app/src/main/java/com/jotty/android/util/NoteImageUrls.kt
@@ -122,9 +122,11 @@ internal fun prepareNoteContentForDisplay(
     val withFonts = convertHtmlFontFamilySpans(stripped)
     val withColors = convertHtmlColorSpans(withFonts)
     val withResolvedHtmlSrc = resolveNoteImageUrlsInHtml(withColors, jottyServerUrl)
-    val htmlAsMarkdown = convertHtmlImagesToMarkdown(withResolvedHtmlSrc)
-    val withStructure = convertHtmlStructuralElementsToMarkdown(htmlAsMarkdown)
-    val withTables = convertHtmlTablesToGfm(withStructure)
-    val separated = separateMarkdownHeadingsFromTables(withTables)
+    val withImages = convertHtmlImagesToMarkdown(withResolvedHtmlSrc)
+    // HTML tables must become GFM before structural HTML→markdown: the paragraph regex
+    // stops at the first </p> and breaks layout when cells (or a wrapper <p>) contain tables.
+    val withTables = convertHtmlTablesToGfm(withImages)
+    val withStructure = convertHtmlStructuralElementsToMarkdown(withTables)
+    val separated = separateMarkdownHeadingsFromTables(withStructure)
     return resolveNoteImageUrlsInMarkdown(separated, jottyServerUrl)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,7 +333,11 @@
     <string name="wysiwyg_table">Table</string>
     <string name="note_edit_mode_visual">Visual</string>
     <string name="note_edit_mode_markdown">Markdown</string>
-    <string name="rich_note_editor_description">Default to the visual editor when editing notes. You can always switch to markdown source while editing. HTML notes (tables, images from the web app) open in visual mode automatically.</string>
+    <string name="rich_note_editor_description">Experimental visual editor (WebView). Default for plain notes when enabled; encrypted and HTML-heavy notes open in Markdown source for safer editing.</string>
+    <string name="encrypted_note_visual_editor_warning">Encrypted note — visual editing is risky. Tables and HTML can be mangled when saving. Use Markdown source, or save from view mode (tap Save without Edit) to re-encrypt without opening the visual editor.</string>
+    <string name="encrypted_note_visual_editor_confirm_title">Use visual editor on this encrypted note?</string>
+    <string name="encrypted_note_visual_editor_confirm_message">The visual editor has corrupted encrypted notes that contain tables or HTML. Markdown source is strongly recommended. Only continue if you accept that risk.</string>
+    <string name="encrypted_note_visual_editor_confirm_continue">Use visual editor anyway</string>
     <string name="content_padding">Content padding</string>
     <string name="content_padding_description">Vertical spacing at top and bottom of screens</string>
     <string name="content_padding_comfortable">Comfortable</string>

--- a/app/src/test/java/com/jotty/android/util/MarkdownHtmlTablesTest.kt
+++ b/app/src/test/java/com/jotty/android/util/MarkdownHtmlTablesTest.kt
@@ -165,6 +165,61 @@ class MarkdownHtmlTablesTest {
     }
 
     @Test
+    fun `prepareNoteContentForDisplay converts table wrapped in paragraph`() {
+        val html =
+            """
+            <p>
+            <table>
+              <tbody>
+                <tr>
+                  <th><p>Hvem</p></th>
+                  <th><p>Beløp</p></th>
+                </tr>
+                <tr>
+                  <td><p>Nuqq</p></td>
+                  <td><p>1000kr</p></td>
+                </tr>
+              </tbody>
+            </table>
+            </p>
+            """.trimIndent()
+        val displayed = prepareNoteContentForDisplay(html, null)
+        assertFalse("raw th should not reach Markwon", displayed.contains("<th"))
+        assertTrue(displayed.contains("| Hvem | Beløp |"))
+        assertTrue(displayed.contains("| Nuqq | 1000kr |"))
+    }
+
+    @Test
+    fun `prepareNoteContentForDisplay converts jotty colgroup table with th header row`() {
+        val html =
+            """
+            <table style="width: 100%;">
+              <colgroup>
+                <col style="width: 25%;">
+                <col style="width: 25%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <tbody>
+                <tr>
+                  <th colspan="1" rowspan="1"><p>Hvem</p></th>
+                  <th colspan="1" rowspan="1"><p>Beløp</p></th>
+                  <th colspan="1" rowspan="1"><p>Kommentar</p></th>
+                </tr>
+                <tr>
+                  <td colspan="1" rowspan="1"><p>Nuqq</p></td>
+                  <td colspan="1" rowspan="1"><p>1000kr</p></td>
+                  <td colspan="1" rowspan="1"><p>2026-05-15 - Vipps</p></td>
+                </tr>
+              </tbody>
+            </table>
+            """.trimIndent()
+        val displayed = prepareNoteContentForDisplay(html, null)
+        assertFalse(displayed.contains("<th"))
+        assertTrue(displayed.contains("| Hvem | Beløp | Kommentar |"))
+        assertTrue(displayed.contains("| Nuqq | 1000kr | 2026-05-15 - Vipps |"))
+    }
+
+    @Test
     fun `prepareNoteContentForDisplay renders html heading before gfm table`() {
         val html = "<p># test</p><table><tr><th>Navn</th><th>asd</th></tr><tr><td>sada</td><td>123</td></tr></table>"
         val displayed = prepareNoteContentForDisplay(html, null)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # App version (single source of truth — bump when cutting a release)
-VERSION_NAME=1.7.3
-VERSION_CODE=38
+VERSION_NAME=1.7.4
+VERSION_CODE=39
 
 android.uniquePackageNames=false
 android.r8.strictFullModeForKeepRules=true

--- a/scripts/publish-release.ps1
+++ b/scripts/publish-release.ps1
@@ -123,9 +123,7 @@ $releaseNotesPath = Join-Path $repoRoot ".gh-release-$Version.md"
 $installBlurb = @"
 ## Install
 
-Download **`jotty-android-$Version.apk`** from this release (release-signed when CI secrets are configured).
-
-**Updating from an older `*-debug.apk` or mixed signing?** Android may show "App not installed" — uninstall once, then install this APK. Your Jotty server data is unchanged.
+Download **`jotty-android-$Version.apk`** from this release.
 
 **Full changelog:** https://github.com/Darknetzz/jotty-android/blob/v$Version/CHANGELOG.md
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -81,9 +81,7 @@ NOTES_FILE=".gh-release-${VERSION}.md"
 cat > "$NOTES_FILE" <<EOF
 ## Install
 
-Download **\`jotty-android-${VERSION}.apk\`** from this release (release-signed when CI secrets are configured).
-
-**Updating from an older \`*-debug.apk\` or mixed signing?** Android may show "App not installed" — uninstall once, then install this APK. Your Jotty server data is unchanged.
+Download **\`jotty-android-${VERSION}.apk\`** from this release.
 
 **Full changelog:** https://github.com/Darknetzz/jotty-android/blob/v${VERSION}/CHANGELOG.md
 


### PR DESCRIPTION
## Summary

Stable release **v1.7.4** (gradle.properties / CHANGELOG).

## Test plan

- [ ] CI green on this PR
- [ ] Merge to `main`
- [ ] GitHub release `v1.7.4` published (Release APK workflow attaches APK)
- [ ] `dev` fast-forwards to `main` via sync-dev-with-main workflow

See [CHANGELOG.md](https://github.com/Darknetzz/jotty-android/blob/dev/CHANGELOG.md) on `dev` for full notes.