### PR TITLE
feat: add custom headers support

### DIFF
--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -9,6 +9,7 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 ### Added
 
 - **Clone notes and checklists** — List and detail ⋮ menus include **Clone** with a category picker (matching Jotty web). Creates a copy titled “(Copy)” via the REST API; encrypted note bodies are copied as stored.
+- **Custom HTTP headers per instance** - Add/remove arbitrary request headers (e.g. for reverse-proxy authentication) under **Optional details** when adding or editing an instance. Headers are stored with the instance and sent on every API request including background sync.
 
 ---
 

--- a/app/src/main/java/com/jotty/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/jotty/android/data/api/ApiClient.kt
@@ -13,17 +13,19 @@ object ApiClient {
     fun create(
         baseUrl: String,
         apiKey: String,
+        customHeaders: Map<String, String> = emptyMap(),
     ): JottyApi {
         val normalizedBase = normalizeBaseUrl(baseUrl)
 
         val client =
             OkHttpClient.Builder()
                 .addInterceptor { chain ->
-                    chain.proceed(
-                        chain.request().newBuilder()
-                            .addHeader(HEADER_API_KEY, apiKey)
-                            .build(),
-                    )
+                    val builder = chain.request().newBuilder()
+                        .addHeader(HEADER_API_KEY, apiKey)
+                    customHeaders.forEach { (name, value) ->
+                        if (name.isNotBlank()) builder.addHeader(name.trim(), value)
+                    }
+                    chain.proceed(builder.build())
                 }
                 .apply {
                     if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/jotty/android/data/local/OfflineSyncWorker.kt
+++ b/app/src/main/java/com/jotty/android/data/local/OfflineSyncWorker.kt
@@ -30,7 +30,7 @@ class OfflineSyncWorker(
         instances.forEach { instance ->
             if (instance.serverUrl.isBlank() || instance.apiKey.isBlank()) return@forEach
             runCatching {
-                val api = ApiClient.create(instance.serverUrl, instance.apiKey)
+                val api = ApiClient.create(instance.serverUrl, instance.apiKey, instance.customHeaders)
                 val notesRepo =
                     OfflineNotesRepository(
                         context = applicationContext,

--- a/app/src/main/java/com/jotty/android/data/preferences/JottyInstance.kt
+++ b/app/src/main/java/com/jotty/android/data/preferences/JottyInstance.kt
@@ -3,6 +3,7 @@ package com.jotty.android.data.preferences
 /**
  * A saved Jotty server connection (name, URL, API key).
  * [colorHex] optional (e.g. "0xFF6200EE") for list/icon tint; null = default.
+ * [customHeaders] optional extra HTTP headers sent with every request (e.g. for reverse-proxy auth).
  */
 data class JottyInstance(
     val id: String,
@@ -10,4 +11,5 @@ data class JottyInstance(
     val serverUrl: String,
     val apiKey: String,
     val colorHex: Long? = null,
+    val customHeaders: Map<String, String> = emptyMap(),
 )

--- a/app/src/main/java/com/jotty/android/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/main/MainScreen.kt
@@ -137,11 +137,11 @@ fun MainScreen(
         }
 
     val api =
-        remember(serverUrl, apiKey) {
+        remember(serverUrl, apiKey, currentInstance) {
             val url = serverUrl
             val key = apiKey
             if (!url.isNullOrBlank() && !key.isNullOrBlank()) {
-                ApiClient.create(url, key)
+                ApiClient.create(url, key, currentInstance?.customHeaders.orEmpty())
             } else {
                 null
             }

--- a/app/src/main/java/com/jotty/android/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/jotty/android/ui/setup/SetupScreen.kt
@@ -298,6 +298,15 @@ private fun InstanceForm(
     var serverUrl by remember(initialInstance) { mutableStateOf(initialInstance?.serverUrl ?: "") }
     var apiKey by remember(initialInstance) { mutableStateOf(initialInstance?.apiKey ?: "") }
     var colorHex by remember(initialInstance) { mutableStateOf(initialInstance?.colorHex) }
+    // Custom headers: immutable list of (name, value) pairs; reassigned on every edit
+    var customHeaders by remember(initialInstance) {
+        mutableStateOf<List<Pair<String, String>>>(
+            initialInstance?.customHeaders
+                ?.entries
+                ?.map { it.key to it.value }
+                ?: emptyList()
+        )
+    }
     var apiKeyVisible by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
     var loading by remember { mutableStateOf(false) }
@@ -456,6 +465,69 @@ private fun InstanceForm(
                     }
                 }
             }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.custom_headers_label),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = stringResource(R.string.custom_headers_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp, bottom = 6.dp),
+            )
+            for (index in customHeaders.indices) {
+                val (headerName, headerValue) = customHeaders[index]
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedTextField(
+                        value = headerName,
+                        onValueChange = { newName ->
+                            customHeaders = customHeaders.toMutableList().also { it[index] = newName to headerValue }
+                        },
+                        label = { Text(stringResource(R.string.custom_header_name)) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                    OutlinedTextField(
+                        value = headerValue,
+                        onValueChange = { newValue ->
+                            customHeaders = customHeaders.toMutableList().also { it[index] = headerName to newValue }
+                        },
+                        label = { Text(stringResource(R.string.custom_header_value)) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = {
+                            customHeaders = customHeaders.toMutableList().also { it.removeAt(index) }
+                        },
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = stringResource(R.string.custom_header_remove),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+            TextButton(
+                onClick = { customHeaders = customHeaders + ("" to "") },
+                contentPadding = PaddingValues(horizontal = 0.dp),
+            ) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(stringResource(R.string.custom_header_add))
+            }
         }
 
         error?.let { msg ->
@@ -493,7 +565,7 @@ private fun InstanceForm(
                                 return@launch
                             }
 
-                            val api = ApiClient.create(url, key)
+                            val api = ApiClient.create(url, key, customHeaders.filter { it.first.isNotBlank() }.toMap())
                             api.health()
                             // health() is unauthenticated; verify the API key with an
                             // authenticated endpoint so a wrong key fails here instead of later.
@@ -506,6 +578,7 @@ private fun InstanceForm(
                                     serverUrl = url,
                                     apiKey = key,
                                     colorHex = colorHex,
+                                    customHeaders = customHeaders.filter { it.first.isNotBlank() }.toMap(),
                                 )
                             settingsRepository.addInstance(instance, setAsCurrent = setAsCurrentOnConnect)
                             if (isEdit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,6 +281,12 @@
     <string name="edit_instance_action">Edit instance</string>
     <string name="remove_instance">Remove instance</string>
     <string name="no_color">—</string>
+    <string name="custom_headers_label">Custom HTTP headers</string>
+    <string name="custom_headers_hint">Extra headers sent with every request (e.g. for reverse-proxy authentication). Blank header names are ignored.</string>
+    <string name="custom_header_name">Header name</string>
+    <string name="custom_header_value">Value</string>
+    <string name="custom_header_add">Add header</string>
+    <string name="custom_header_remove">Remove header</string>
     <string name="untitled">Untitled</string>
 
     <!-- Settings -->


### PR DESCRIPTION
Hi!

full disclaimer: AI was used to make this pr, even though I just dabble with kotlin, I couldn't have wrote some lines of code  without help. I do know what each line does though

That said this pr adds support for adding custom headers support for people using Jotty behind a reverse proxy or some kind of auth.

I tried to keep it as simple as possible to make it easier to read.

The final result is simply this:
<img width="527" height="959" alt="{983B817D-51DF-4DBF-9462-7BEBE77110B9}" src="https://github.com/user-attachments/assets/3f220484-3620-4518-887c-526ab462aeb5" />

Tested and working!
