### PR TITLE
chore(deps): land safe gradle-weekly bumps without compileSdk 37

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
         versions: [">=1.19.0"]
       - dependency-name: "androidx.lifecycle:*"
         versions: [">=2.11.0"]
+      - dependency-name: "androidx.navigation:navigation-compose"
+        versions: [">=2.10.0"]
+      - dependency-name: "androidx.compose:compose-bom"
+        versions: [">=2026.08.00"]
       # compose-markdown 0.6+ requires Coil 3; bump with NoteImageLoader migration
       - dependency-name: "com.github.jeziellago:compose-markdown"
         versions: [">=0.6.0"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Changed
 
-- **Dependencies** — AGP 9.3.1 ([#92](https://github.com/Darknetzz/jotty-android/pull/92)), Compose BOM 2026.06.01, KSP 2.3.10, Bouncy Castle 1.85, Gradle 9.6.1, and ktlint Gradle plugin 13.1.0. Kotlin stays on 2.3.21 until a coordinated 2.4 upgrade; Lifecycle stays on 2.10 (2.11 needs compileSdk 37); compose-markdown stays on 0.5.8 (0.6+ needs Coil 3).
-- **Dependabot** — Ignore rules now cover Kotlin Gradle plugin ids (not only `org.jetbrains.kotlin:*`), exclude Kotlin from grouped weekly/major PRs, and block Lifecycle 2.11+, compose-markdown 0.6+, until their prerequisites land (see closed [#85](https://github.com/Darknetzz/jotty-android/pull/85)).
-- **GitHub Actions** — `actions/checkout` v7, `android-emulator-runner` 2.38 ([#79](https://github.com/Darknetzz/jotty-android/pull/79)), and `actions/setup-java` 5.6.0 ([#89](https://github.com/Darknetzz/jotty-android/pull/89)).
+- **Dependencies** — AGP 9.3.2, KSP 2.3.11, Bouncy Castle 1.85.2, fragment-ktx 1.9.0, and Gradle 9.7.1 (safe subset of [#98](https://github.com/Darknetzz/jotty-android/pull/98)). Compose BOM stays on 2026.06.01 and navigation-compose on 2.9.8 until compileSdk 37; Kotlin stays on 2.3.21 until a coordinated 2.4 upgrade; Lifecycle stays on 2.10 (2.11 needs compileSdk 37); compose-markdown stays on 0.5.8 (0.6+ needs Coil 3).
+- **Dependabot** — Ignore rules now cover Kotlin Gradle plugin ids (not only `org.jetbrains.kotlin:*`), exclude Kotlin from grouped weekly/major PRs, and block Lifecycle 2.11+, Compose BOM 2026.08+, navigation-compose 2.10+, compose-markdown 0.6+, until their prerequisites land (see closed [#85](https://github.com/Darknetzz/jotty-android/pull/85), [#98](https://github.com/Darknetzz/jotty-android/pull/98)).
+- **GitHub Actions** — `actions/checkout` v7, `android-emulator-runner` 2.38 ([#79](https://github.com/Darknetzz/jotty-android/pull/79)), and `actions/setup-java` 6.0.0 ([#97](https://github.com/Darknetzz/jotty-android/pull/97)).
 
 ### Fixed
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,7 +115,7 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.13.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0") // 2.11+ requires compileSdk 37
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")
-    implementation("androidx.navigation:navigation-compose:2.9.8")
+    implementation("androidx.navigation:navigation-compose:2.9.8") // 2.10+ requires compileSdk 37 (see Dependabot PR #98)
 
     // Retrofit for REST API
     implementation("com.squareup.retrofit2:retrofit:3.0.0")
@@ -145,12 +145,12 @@ dependencies {
     implementation("io.coil-kt:coil:2.7.0")
 
     // Encryption: Argon2 + XChaCha20 (for Jotty encrypted notes)
-    implementation("org.bouncycastle:bcprov-jdk18on:1.85")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.85.2")
 
     // Biometric authentication (note passphrase protection)
     implementation("androidx.biometric:biometric:1.1.0")
     // FragmentActivity is required by BiometricPrompt; declared explicitly to avoid relying on transitive resolution.
-    implementation("androidx.fragment:fragment-ktx:1.8.9")
+    implementation("androidx.fragment:fragment-ktx:1.9.0")
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -12,14 +12,18 @@ The top section tracks the rolling [`dev-latest`](https://github.com/Darknetzz/j
 
 ### Changed
 
-- **Dependencies** — AGP 9.3.1 ([#92](https://github.com/Darknetzz/jotty-android/pull/92)), Compose BOM 2026.06.01, KSP 2.3.10, Bouncy Castle 1.85, Gradle 9.6.1, and ktlint Gradle plugin 13.1.0. Kotlin stays on 2.3.21 until a coordinated 2.4 upgrade; Lifecycle stays on 2.10 (2.11 needs compileSdk 37); compose-markdown stays on 0.5.8 (0.6+ needs Coil 3).
-- **Dependabot** — Ignore rules now cover Kotlin Gradle plugin ids (not only `org.jetbrains.kotlin:*`), exclude Kotlin from grouped weekly/major PRs, and block Lifecycle 2.11+, compose-markdown 0.6+, until their prerequisites land (see closed [#85](https://github.com/Darknetzz/jotty-android/pull/85)).
-- **GitHub Actions** — `actions/checkout` v7, `android-emulator-runner` 2.38 ([#79](https://github.com/Darknetzz/jotty-android/pull/79)), and `actions/setup-java` 5.6.0 ([#89](https://github.com/Darknetzz/jotty-android/pull/89)).
+- **Dependencies** — AGP 9.3.2, KSP 2.3.11, Bouncy Castle 1.85.2, fragment-ktx 1.9.0, and Gradle 9.7.1 (safe subset of [#98](https://github.com/Darknetzz/jotty-android/pull/98)). Compose BOM stays on 2026.06.01 and navigation-compose on 2.9.8 until compileSdk 37; Kotlin stays on 2.3.21 until a coordinated 2.4 upgrade; Lifecycle stays on 2.10 (2.11 needs compileSdk 37); compose-markdown stays on 0.5.8 (0.6+ needs Coil 3).
+- **Dependabot** — Ignore rules now cover Kotlin Gradle plugin ids (not only `org.jetbrains.kotlin:*`), exclude Kotlin from grouped weekly/major PRs, and block Lifecycle 2.11+, Compose BOM 2026.08+, navigation-compose 2.10+, compose-markdown 0.6+, until their prerequisites land (see closed [#85](https://github.com/Darknetzz/jotty-android/pull/85), [#98](https://github.com/Darknetzz/jotty-android/pull/98)).
+- **GitHub Actions** — `actions/checkout` v7, `android-emulator-runner` 2.38 ([#79](https://github.com/Darknetzz/jotty-android/pull/79)), and `actions/setup-java` 6.0.0 ([#97](https://github.com/Darknetzz/jotty-android/pull/97)).
 
 ### Fixed
 
 - **Visual editor table toolbar on Android** — Table edit controls now appear for any note that contains a table (detected from note content, not only when the cursor is inside a cell). The table button opens the row/column/exit menu instead of “Insert table” on existing table notes. Delete row/column are enabled correctly for Jotty web tables (cells wrapped in `<p>` tags).
 - **Compose lint (LocalContext resources)** — Category-filter empty snackbars use `LocalResources` instead of `LocalContext.getString`, satisfying the new Compose lint check from the BOM/AGP bump.
+
+### Documentation
+
+- **Jotty 1.27.0 compatibility** — Documented that Kanban card comments (and TipTap description editing) are web/server-action only with no public REST yet; Android needs no client change for REST compatibility ([docs/JOTTY_SERVER_COMPATIBILITY.md](docs/JOTTY_SERVER_COMPATIBILITY.md)).
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "9.3.1"
+agp = "9.3.2"
 kotlin = "2.3.21"
-ksp = "2.3.10"
-compose-bom = "2026.06.01"
+ksp = "2.3.11"
+compose-bom = "2026.06.01" # 2026.08+ needs compileSdk 37 (see Dependabot PR #98)
 ktlint = "13.1.0" # 14.x fails ktlintTestSourceSetCheck until formatted (Dependabot PR #61)
 reorderable = "3.1.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary
- Land safe subset of Dependabot [#98](https://github.com/Darknetzz/jotty-android/pull/98): AGP 9.3.2, KSP 2.3.11, Gradle 9.7.1, Bouncy Castle 1.85.2, fragment-ktx 1.9.0.
- Keep Compose BOM 2026.06.01 and navigation-compose 2.9.8 (both need compileSdk 37).
- Add Dependabot ignores for those blocked packages; document in changelog (also notes setup-java 6.0.0 from #97).

## Test plan
- [x] `./gradlew.bat test assembleDebug` on this branch